### PR TITLE
OpenLayers/OSM fixes

### DIFF
--- a/includes/services/OpenLayers/OSM/OpenStreetMap.js
+++ b/includes/services/OpenLayers/OSM/OpenStreetMap.js
@@ -44,9 +44,9 @@ OpenLayers.Layer.OSM.Mapnik = OpenLayers.Class(OpenLayers.Layer.OSM, {
      */
     initialize: function(name, options) {
         var url = [
-            "http://a.tile.openstreetmap.org/${z}/${x}/${y}.png",
-            "http://b.tile.openstreetmap.org/${z}/${x}/${y}.png",
-            "http://c.tile.openstreetmap.org/${z}/${x}/${y}.png"
+            "//a.tile.openstreetmap.org/${z}/${x}/${y}.png",
+            "//b.tile.openstreetmap.org/${z}/${x}/${y}.png",
+            "//c.tile.openstreetmap.org/${z}/${x}/${y}.png"
         ];
         options = OpenLayers.Util.extend({
             numZoomLevels: 19,

--- a/includes/services/OpenLayers/jquery.openlayers.js
+++ b/includes/services/OpenLayers/jquery.openlayers.js
@@ -20,28 +20,28 @@
 				marker = new OpenLayers.Marker(markerData.lonlat, new OpenLayers.Icon(markerLayer.defaultIcon));
 			}
 
-			// This is the handler for the mousedown event on the marker, and displays the popup.
-			marker.events.register('mousedown', marker,
-				function (evt) {
-					if (markerData.link) {
-						window.location.href = markerData.link;
-					} else if (markerData.text !== '') {
-						var popup = new OpenLayers.Feature(markerLayer, markerData.lonlat).createPopup(true);
-						popup.setContentHTML(markerData.text);
-						markerLayer.map.addPopup(popup);
-						OpenLayers.Event.stop(evt); // Stop the event.
-					}
-
-					if (markerData.visitedicon && markerData.visitedicon !== '') {
-						if(markerData.visitedicon === 'on'){
-							//when keyword 'on' is set, set visitedicon to a default official marker
-							markerData.visitedicon = mw.config.get('wgScriptPath')+'/extensions/Maps/includes/services/OpenLayers/OpenLayers/img/marker3.png';
-						}
-						marker.setUrl(markerData.visitedicon);
-						markerData.visitedicon = undefined;
-					}
+			// This is the handler for the mousedown/touchstart event on the marker, and displays the popup.
+			function handleClickEvent(evt) {
+				if (markerData.link) {
+					window.location.href = markerData.link;
+				} else if (markerData.text !== '') {
+					var popup = new OpenLayers.Feature(markerLayer, markerData.lonlat).createPopup(true);
+					popup.setContentHTML(markerData.text);
+					markerLayer.map.addPopup(popup);
+					OpenLayers.Event.stop(evt); // Stop the event.
 				}
-			);
+
+				if (markerData.visitedicon && markerData.visitedicon !== '') {
+					if(markerData.visitedicon === 'on'){
+						//when keyword 'on' is set, set visitedicon to a default official marker
+						markerData.visitedicon = mw.config.get('wgScriptPath')+'/extensions/Maps/includes/services/OpenLayers/OpenLayers/img/marker3.png';
+					}
+					marker.setUrl(markerData.visitedicon);
+					markerData.visitedicon = undefined;
+				}
+			}
+			marker.events.register('mousedown', marker, handleClickEvent);
+			marker.events.register('touchstart', marker, handleClickEvent);
 
 			return marker;
 		};


### PR DESCRIPTION
1. Using protocol relative URLs fixes browser warnings if Wiki is running via HTTPS. Unfortunately opencyclemap doesn't seem to support HTTPS (properly) yet.

2. Markers in OpenLayers didn't handle touchstart events. Markers couldn't get selected.