### PR TITLE
Replace deprecated Xml::escapeJsString()

### DIFF
--- a/includes/Maps_Mapper.php
+++ b/includes/Maps_Mapper.php
@@ -54,12 +54,12 @@ final class MapsMapper {
 				if ( $s != '{' ) {
 					$s .= ', ';
 				}
-				$s .= '"' . Xml::escapeJsString( $name ) . '": ' .
+				$s .= '"' . Xml::encodeJsVar( $name ) . '": ' .
 					self::encodeJsVar( $elt );
 			}
 			$s .= '}';
 		} else {
-			$s = '"' . Xml::escapeJsString( $value ) . '"';
+			$s = '"' . Xml::encodeJsVar( $value ) . '"';
 		}
 		return $s;
 	}


### PR DESCRIPTION
This method has been deprecated since MediaWiki 1.21. It is recommended to use
Xml::encodeJsVar() or Xml::encodeJsCall() instead.