### PR TITLE
Update link to markercluster resource

### DIFF
--- a/includes/services/GoogleMaps3/gm3-util-library/markerclusterer.js
+++ b/includes/services/GoogleMaps3/gm3-util-library/markerclusterer.js
@@ -1575,7 +1575,7 @@ MarkerClusterer.BATCH_SIZE_IE = 500;
  * @type {string}
  * @constant
  */
-MarkerClusterer.IMAGE_PATH = "//google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/images/m";
+MarkerClusterer.IMAGE_PATH = "//cdn.rawgit.com/googlemaps/js-marker-clusterer/gh-pages/images/m";
 
 
 /**


### PR DESCRIPTION
Fix location of markercluster files. Refs issue https://github.com/JeroenDeDauw/Maps/issues/138

* New code location according to: [stackoverflow - 37179980](http://stackoverflow.com/questions/37179980/markercluster-v3-stopped-working-properly?answertab=votes#tab-top)
* Code link set according to: [stackoverflow - 17341122](http://stackoverflow.com/questions/17341122/link-and-execute-external-javascript-file-hosted-on-github/18049842#18049842)