### PR TITLE
add removeMarkers to leaflet and openlayers

### DIFF
--- a/includes/services/GoogleMaps3/jquery.googlemap.js
+++ b/includes/services/GoogleMaps3/jquery.googlemap.js
@@ -90,7 +90,7 @@
 				labelClass:'markerwithlabel'
 			};
 
-			if (markerData.icon !== '') {
+			if (!markerData.hasOwnProperty('icon') || markerData.icon !== '') {
 				markerOptions.icon = markerData.icon;
 			}
 
@@ -256,8 +256,6 @@
 								label.appendChild(text);
 
 								toggleDiv.appendChild(label);
-
-								console.log(toggleDiv);
 							})(docs[i]);
 						}
 						_this.map.controls[google.maps.ControlPosition.TOP_RIGHT].push(toggleDiv);

--- a/includes/services/Leaflet/jquery.leaflet.js
+++ b/includes/services/Leaflet/jquery.leaflet.js
@@ -3,13 +3,15 @@
  * @see https://www.mediawiki.org/wiki/Extension:Maps
  *
  * @author Pavel Astakhov < pastakhov@yandex.ru >
+ * @author Peter Grassberger < petertheone@gmail.com >
  */
 
-(function ($, mw) {
+(function ($, mw, L) {
 	$.fn.leafletmaps = function ( options ) {
 		var _this = this;
 		this.map = null;
 		this.options = options;
+		this.markers = [];
 
 		/**
 		 * array point of all map elements (markers, lines, polygons, etc.)
@@ -26,7 +28,7 @@
 		this.addMarker = function (properties) {
 			this.points.push( new L.LatLng(properties.lat, properties.lon) );
 
-			if (properties.icon === '') {
+			if (!properties.hasOwnProperty('icon') || properties.icon === '') {
 				var icon = new L.Icon.Default();
 			} else {
 				var icon = new L.Icon({
@@ -40,7 +42,27 @@
 			};
 
 			var marker = L.marker( [properties.lat, properties.lon], markerOptions ).addTo( this.map );
-			if( properties.text.length > 0 ) marker.bindPopup( properties.text );
+			if( properties.hasOwnProperty('text') && properties.text.length > 0 ) marker.bindPopup( properties.text );
+
+			this.markers.push(marker);
+		};
+
+		this.removeMarker = function (marker) {
+			this.map.removeLayer(marker);
+			this.points = [];
+			this.markers = this.markers.filter(function(object) {
+				return object !== marker;
+			});
+		};
+
+		this.removeMarkers = function () {
+			var map = this.map;
+			$.each(this.markers, function(index, marker) {
+				map.removeLayer(marker);
+			});
+
+			this.points = [];
+			this.markers = [];
 		};
 
 		this.addLine = function (properties) {
@@ -197,6 +219,7 @@
 						}
 						break;
 				}
+				this.points = [];
 			} else {
 				centre = new L.LatLng(options.centre.lat, options.centre.lon);
 			}
@@ -210,4 +233,4 @@
 		return this;
 
 	};
-})(jQuery, window.mediaWiki);
+})(jQuery, window.mediaWiki, L);

--- a/includes/services/OpenLayers/jquery.openlayers.js
+++ b/includes/services/OpenLayers/jquery.openlayers.js
@@ -4,13 +4,15 @@
  *
  * @author Jeroen De Dauw <jeroendedauw at gmail dot com>
  * @author Daniel Werner
+ * @author Peter Grassberger < petertheone@gmail.com >
  *
  * @todo This whole JS is very blown up and could use some quality refactoring.
  */
 
-(function ($, mw) {
+(function ($, mw, OpenLayers) {
 	$.fn.openlayers = function (mapElementId, options) {
 
+		this.map = null;
 		this.options = options;
 
 		OpenLayers._getScriptLocation = function() {
@@ -20,7 +22,7 @@
 		this.getOLMarker = function (markerLayer, markerData) {
 			var marker;
 
-			if (markerData.icon !== "") {
+			if (markerData.hasOwnProperty('icon') && markerData.icon !== "") {
 				marker = new OpenLayers.Marker(markerData.lonlat, new OpenLayers.Icon(markerData.icon));
 			} else {
 				marker = new OpenLayers.Marker(markerData.lonlat, new OpenLayers.Icon(markerLayer.defaultIcon));
@@ -64,45 +66,56 @@
 				bounds = new OpenLayers.Bounds();
 			}
 
-			var groupLayers = new Object();
-			var groups = 0;
+			this.groupLayers = new Object();
+			this.groups = 0;
 
 			for (var i = locations.length - 1; i >= 0; i--) {
-
-				var location = locations[i];
-
-				// Create a own marker-layer for the marker group:
-				if (!groupLayers[ location.group ]) {
-					// in case no group is specified, use default marker layer:
-					var layerName = location.group != '' ? location.group : mw.msg('maps-markers');
-					var curLayer = new OpenLayers.Layer.Markers(layerName);
-					groups++;
-					curLayer.id = 'markerLayer' + groups;
-					// define default icon, one of ten in different colors, if more than ten layers, colors will repeat:
-					curLayer.defaultIcon = mw.config.get( 'egMapsScriptPath' ) + '/includes/services/OpenLayers/OpenLayers/img/marker' + ( ( groups + 10 ) % 10 ) + '.png';
-					map.addLayer(curLayer);
-					groupLayers[ location.group ] = curLayer;
-				} else {
-					// if markers of this group exist already, they have an own layer already
-					var curLayer = groupLayers[ location.group ];
-				}
-
-				location.lonlat = new OpenLayers.LonLat(location.lon, location.lat);
-
-				if (!hasImageLayer) {
-					location.lonlat.transform(new OpenLayers.Projection("EPSG:4326"), new OpenLayers.Projection("EPSG:900913"));
-				}
-
-				if (bounds != null) bounds.extend(location.lonlat); // Extend the bounds when no center is set.
-				var marker = this.getOLMarker(curLayer, location);
-				this.markers.push({
-					target:marker,
-					data:location
-				});
-				curLayer.addMarker(marker); // Create and add the marker.
+				this.addMarker( locations[i] );
 			}
 
 			if (bounds != null) map.zoomToExtent(bounds); // If a bounds object has been created, use it to set the zoom and center.
+		};
+
+		this.addMarker = function (markerData) {
+			markerData.group = !markerData.hasOwnProperty('group') ? '' : markerData.group;
+			// Create a own marker-layer for the marker group:
+			if (!this.groupLayers[ markerData.group ]) {
+				// in case no group is specified, use default marker layer:
+				var layerName = markerData.group != '' ? markerData.group : mw.msg('maps-markers');
+				var curLayer = new OpenLayers.Layer.Markers(layerName);
+				this.groups++;
+				curLayer.id = 'markerLayer' + this.groups;
+				// define default icon, one of ten in different colors, if more than ten layers, colors will repeat:
+				curLayer.defaultIcon = mw.config.get( 'egMapsScriptPath' ) + '/includes/services/OpenLayers/OpenLayers/img/marker' + ( ( this.groups + 10 ) % 10 ) + '.png';
+				map.addLayer(curLayer);
+				this.groupLayers[ markerData.group ] = curLayer;
+			} else {
+				// if markers of this group exist already, they have an own layer already
+				var curLayer = this.groupLayers[ markerData.group ];
+			}
+
+			markerData.lonlat = new OpenLayers.LonLat(markerData.lon, markerData.lat);
+
+			if (!hasImageLayer) {
+				markerData.lonlat.transform(new OpenLayers.Projection("EPSG:4326"), new OpenLayers.Projection("EPSG:900913"));
+			}
+
+			var marker = this.getOLMarker(curLayer, markerData);
+			this.markers.push({
+				target:marker,
+				data:markerData
+			});
+			curLayer.addMarker(marker); // Create and add the marker.
+		};
+
+		this.removeMarkers = function () {
+			var map = this.map;
+			$.each(this.groupLayers, function(index, layer) {
+				map.removeLayer(layer);
+			});
+			this.groupLayers = new Object();
+			this.groups = 0;
+			this.markers = [];
 		};
 
 		this.addControls = function (map, controls, mapElement) {
@@ -686,4 +699,4 @@
 		return this;
 
 	};
-})(jQuery, window.mediaWiki);
+})(jQuery, window.mediaWiki, OpenLayers);


### PR DESCRIPTION
add removeMarkers functions to leaflet and openlayers (googlemaps3 already has this function) as noted in #117.

This is required for https://github.com/SemanticMediaWiki/SemanticMaps/pull/52 to work with leaflet and openlayers.