### PR TITLE
add rotateControl to googlemaps

### DIFF
--- a/includes/services/GoogleMaps3/Maps_GoogleMaps3.php
+++ b/includes/services/GoogleMaps3/Maps_GoogleMaps3.php
@@ -60,7 +60,8 @@ class MapsGoogleMaps3 extends MapsMappingService {
 		'zoom',
 		'type',
 		'scale',
-		'streetview'
+		'streetview',
+		'rotate'
 	];
 
 	/**

--- a/includes/services/GoogleMaps3/jquery.googlemap.js
+++ b/includes/services/GoogleMaps3/jquery.googlemap.js
@@ -459,6 +459,7 @@
 			mapOptions.mapTypeControl = $.inArray('type', options.controls) != -1;
 			mapOptions.scaleControl = $.inArray('scale', options.controls) != -1;
 			mapOptions.streetViewControl = $.inArray('streetview', options.controls) != -1;
+			mapOptions.rotateControl = $.inArray('rotate', options.controls) != -1;
 
 			for (i in options.types) {
 				if (typeof( options.types[i] ) !== 'function') {


### PR DESCRIPTION
fix #158

Not shown by default.

Usage:

    | controls = type, rotate

or

    | controls = pan, zoom, type, scale, streetview, rotate

Tested.