### PR TITLE
Remove composer autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,6 @@
 		"data-values/common": "~0.3.1"
 	},
 	"autoload": {
-		"files" : [
-			"Maps.php"
-		],
 		"psr-4": {
 			"Maps\\": "src/Maps/"
 		},


### PR DESCRIPTION
This breaks running composer test (and any other command) for MediaWiki core, because it tries to autoload Maps.php which then exits because `MEDIAWIKI` constant is not defined.
