### PR TITLE
Do not use SMW class alias

### DIFF
--- a/SemanticMaps/src/SM_AreaValueDescription.php
+++ b/SemanticMaps/src/SM_AreaValueDescription.php
@@ -2,6 +2,7 @@
 
 use DataValues\Geo\Values\LatLongValue;
 use SMW\DataValueFactory;
+use SMW\Query\Language\ValueDescription;
 
 /**
  * Description of a geographical area defined by a coordinates set and a distance to the bounds.
@@ -15,7 +16,7 @@ use SMW\DataValueFactory;
  * 
  * TODO: would be awesome to use Spatial Extensions to select coordinates
  */
-class SMAreaValueDescription extends SMWValueDescription {
+class SMAreaValueDescription extends ValueDescription {
 	
 	/**
 	 * Associative array containing the bounds of the area, or false when not set.


### PR DESCRIPTION
Note: update min SMW to 2.1

@mwjames `ValueDescription` has a `@since 1.6` tag, which is kinda misleading. For all I know I moved it and forgot this. Just saying, if you move and leave that as is, it's not ideal.