### PR TITLE
Reordered initialization code

### DIFF
--- a/Maps_Settings.php
+++ b/Maps_Settings.php
@@ -10,9 +10,14 @@
  * @author Jeroen De Dauw
  */
 
-if ( !defined( 'MEDIAWIKI' ) ) {
-	die( 'Not an entry point.' );
-}
+
+// This allows disabling the extension even when it is installed. Can be useful on wiki farms.
+// CAUTION: extensions that depend on Maps will likely either break of disable themselves.
+$GLOBALS['egMapsDisableExtension'] = false;
+
+// This allows disabling the Semantic MediaWiki integration.
+$GLOBALS['egMapsDisableSmwIntegration'] = false;
+
 
 // Mapping services configuration
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 	"require": {
 		"php": ">=5.5",
 		"composer/installers": "^1.0.1",
-		"mediawiki/validator": "^2.0.2",
+		"mediawiki/validator": "~2.2",
 		"data-values/geo": "~1.0",
 		"jeroen/file-fetcher": "~3.1",
 		"jeroen/simple-cache": "~2.0"

--- a/includes/services/GoogleMaps3/GoogleMaps3.php
+++ b/includes/services/GoogleMaps3/GoogleMaps3.php
@@ -18,7 +18,7 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 }
 
 call_user_func( function() {
-	global $wgResourceModules, $wgHooks;
+	global $wgResourceModules;
 
 	$pathParts = ( explode( DIRECTORY_SEPARATOR . 'extensions' . DIRECTORY_SEPARATOR, __DIR__, 2 ) );
 
@@ -100,24 +100,4 @@ call_user_func( function() {
 			'googleearth-compiled.js',
 		],
 	];
-
-	$wgHooks['MappingServiceLoad'][] = 'efMapsInitGoogleMaps3';
 } );
-
-/**
- * Initialization function for the Google Maps v3 service.
- *
- * @since 0.6.3
- * @ingroup MapsGoogleMaps3
- *
- * @return boolean true
- */
-function efMapsInitGoogleMaps3() {
-	MapsMappingServices::registerService( 'googlemaps3', MapsGoogleMaps3::class );
-
-	// TODO: kill below code
-	$googleMaps = MapsMappingServices::getServiceInstance( 'googlemaps3' );
-	$googleMaps->addFeature( 'display_map', MapsDisplayMapRenderer::class );
-
-	return true;
-}

--- a/includes/services/Leaflet/Leaflet.php
+++ b/includes/services/Leaflet/Leaflet.php
@@ -19,10 +19,7 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 }
 
 call_user_func( function() {
-	global $wgHooks, $wgResourceModules;
-
-	// Specify the function that will initialize the parser function.
-	$wgHooks['MappingServiceLoad'][] = 'efMapsInitLeaflet';
+	global $wgResourceModules;
 
 	$pathParts = ( explode( DIRECTORY_SEPARATOR . 'extensions' . DIRECTORY_SEPARATOR, __DIR__, 2 ) );
 
@@ -91,18 +88,3 @@ call_user_func( function() {
 		],
 	];
 } );
-
-/**
- * Initialization function for the Leaflet service.
- *
- * @ingroup Leaflet
- *
- * @return boolean true
- */
-function efMapsInitLeaflet() {
-	MapsMappingServices::registerService( 'leaflet', MapsLeaflet::class );
-	$leafletMaps = MapsMappingServices::getServiceInstance( 'leaflet' );
-	$leafletMaps->addFeature( 'display_map', MapsDisplayMapRenderer::class );
-
-	return true;
-}

--- a/includes/services/OpenLayers/OpenLayers.php
+++ b/includes/services/OpenLayers/OpenLayers.php
@@ -18,7 +18,7 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 }
 
 call_user_func( function() {
-	global $wgHooks, $wgResourceModules;
+	global $wgResourceModules;
 
 	$pathParts = ( explode( DIRECTORY_SEPARATOR . 'extensions' . DIRECTORY_SEPARATOR, __DIR__, 2 ) );
 
@@ -46,16 +46,4 @@ call_user_func( function() {
 			'maps-searchmarkers-text',
 		]
 	];
-
-	$wgHooks['MappingServiceLoad'][] = 'efMapsInitOpenLayers';
 } );
-
-function efMapsInitOpenLayers() {
-	MapsMappingServices::registerService(
-		'openlayers',
-		MapsOpenLayers::class,
-		[ 'display_map' => MapsDisplayMapRenderer::class ]
-	);
-
-	return true;
-}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,25 +15,4 @@ if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 	die( 'You need to install this package with Composer before you can run the tests' );
 }
 
-require __DIR__ . '/../vendor/composer/ClassLoader.php';
-
-call_user_func( function() {
-	$loader = new \Composer\Autoload\ClassLoader();
-
-	foreach ( require __DIR__ . '/../vendor/composer/autoload_namespaces.php' as $namespace => $path ) {
-		$loader->set( $namespace, $path );
-	}
-
-	foreach ( require __DIR__ . '/../vendor/composer/autoload_psr4.php' as $namespace => $path ) {
-		$loader->setPsr4( $namespace, $path );
-	}
-
-	$classMap = require __DIR__ . '/../vendor/composer/autoload_classmap.php';
-
-	if ( $classMap ) {
-		$loader->addClassMap( $classMap );
-	}
-
-	$loader->register( true );
-} );
-
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
This adds settings to disable Maps and to disable its SMW integration.
It also removes everything but global declarations from code immediately
executed, so should allow for inclusion of Maps via Composer even without
MediaWiki being loaded.