### PR TITLE
Maps_GoogleGeocoder - address being double urlencoded

### DIFF
--- a/includes/geocoders/Maps_GoogleGeocoder.php
+++ b/includes/geocoders/Maps_GoogleGeocoder.php
@@ -36,7 +36,7 @@ final class MapsGoogleGeocoder extends \Maps\Geocoder {
 	 */	
 	protected function getRequestUrl( $address ) {
 		$urlArgs = [
-			'address' => urlencode( $address )
+			'address' => $address
 		];
 		if ( $GLOBALS['egMapsGMaps3ApiKey'] !== '' ) {
 			$urlArgs['key'] = $GLOBALS['egMapsGMaps3ApiKey'];


### PR DESCRIPTION
Address is double urlencoded:
first time in $urlArgs initialization
second time in wfArrayToCgi function

That breaks it for Unicode-encoded languages (specifically Russian)