### PR TITLE
Fatal error when calling geocode parser function

### DIFF
--- a/Maps.php
+++ b/Maps.php
@@ -130,7 +130,7 @@ $GLOBALS['wgExtensionFunctions'][] = function () {
 	};
 
 	$GLOBALS['wgHooks']['ParserFirstCallInit'][] = function( Parser &$parser ) {
-		$instance = new MapsGeocode( \Maps\MapsFactory::newDefault()->newGeocoder() );
+		$instance = new MapsGeocode( );
 		return $instance->init( $parser );
 	};
 

--- a/includes/parserhooks/Maps_Geocode.php
+++ b/includes/parserhooks/Maps_Geocode.php
@@ -17,8 +17,8 @@ class MapsGeocode extends ParserHook {
 
 	private $geocoder;
 
-	public function __construct( Geocoder $geocoder ) {
-		$this->geocoder = $geocoder;
+	public function __construct( ) {
+		$this->geocoder = \Maps\MapsFactory::newDefault()->newGeocoder();
 		parent::__construct();
 	}
 


### PR DESCRIPTION
I noticed a fatal error when we want to call the `geocode` parser function. You can see an example here : https://sandbox.semantic-mediawiki.org/wiki/Seattle