### PR TITLE
Dynamically resize leaflet custom icons

### DIFF
--- a/includes/services/Leaflet/jquery.leaflet.js
+++ b/includes/services/Leaflet/jquery.leaflet.js
@@ -28,23 +28,32 @@
 		this.createMarker = function (properties) {
 			this.points.push( new L.LatLng(properties.lat, properties.lon) );
 
-			if (!properties.hasOwnProperty('icon') || properties.icon === '') {
-				var icon = new L.Icon.Default();
-			} else {
-				var iconOptions = L.Icon.Default.prototype.options;
-				iconOptions.iconUrl = properties.icon;
-
-				var icon = new L.Icon(iconOptions);
-			}
-
 			var markerOptions = {
-				title:properties.title,
-				icon:icon
+				title:properties.title
 			};
 
 			var marker = L.marker( [properties.lat, properties.lon], markerOptions );
-			if( properties.hasOwnProperty('text') && properties.text.length > 0 ) marker.bindPopup( properties.text );
+			
+			if (properties.hasOwnProperty('icon') && properties.icon !== '') {
+				marker.setOpacity(0);
+				
+				var img = new Image();
+				img.onload = function() {
+					var icon = new L.Icon({ 
+						iconUrl: properties.icon,
+						iconSize: [ img.width, img.height ],
+						iconAnchor: [ img.width / 2, img.height ],
+						popupAnchor: [ -img.width % 2, -img.height*2/3 ]
+					});
+					
+					marker.setIcon(icon);
+					marker.setOpacity(1);
+				};
+				img.src = properties.icon;
+			}
 
+			if( properties.hasOwnProperty('text') && properties.text.length > 0 ) marker.bindPopup( properties.text );
+			
 			return marker;
 		};
 


### PR DESCRIPTION
This fixes #360. 

Because the marker object loads the Leaflet's default icon when no icon is provided, and because we must wait until the custom icon is loaded to know its size, I'm setting the opacity of the marker to 0. Otherwise, the default icon might appear subliminally.

For the position of the popup, I found that 2/3 of the icon's height looked nice. I'm also shifting the popup by 1px to the left when the width is odd. Those choices are of course quite arbitrary, so I'm open for suggestions ;)