### PR TITLE
Leaflet multi layers

### DIFF
--- a/Maps_Settings.php
+++ b/Maps_Settings.php
@@ -318,6 +318,8 @@
 		// used when the user does not provide one.
 		$GLOBALS['egMapsLeafletLayer'] = 'OpenStreetMap';
 
+		$GLOBALS['egMapsLeafletLayers'] = ['OpenStreetMap'];
+
 		$GLOBALS['egMapsLeafletOverlayLayers'] = [
 
 		];

--- a/includes/Maps_DisplayMapRenderer.php
+++ b/includes/Maps_DisplayMapRenderer.php
@@ -273,13 +273,15 @@ class MapsDisplayMapRenderer {
 		$layerDependencies = [];
 
 		if ( $service === 'leaflet' ) {
-			$layerName = $params['layer'];
-			if ( array_key_exists( $layerName, $egMapsLeafletAvailableLayers )
-				&& $egMapsLeafletAvailableLayers[$layerName]
-				&& array_key_exists( $layerName, $egMapsLeafletLayersApiKeys )
-				&& array_key_exists( $layerName, $egMapsLeafletLayerDependencies ) ) {
-				$layerDependencies[] = '<script src="' . $egMapsLeafletLayerDependencies[$layerName] .
-					$egMapsLeafletLayersApiKeys[$layerName] . '"></script>';
+			$layerNames = $params['layers'];
+			foreach ( $layerNames as $layerName ) {
+				if ( array_key_exists( $layerName, $egMapsLeafletAvailableLayers )
+					&& $egMapsLeafletAvailableLayers[$layerName]
+					&& array_key_exists( $layerName, $egMapsLeafletLayersApiKeys )
+					&& array_key_exists( $layerName, $egMapsLeafletLayerDependencies ) ) {
+					$layerDependencies[] = '<script src="' . $egMapsLeafletLayerDependencies[$layerName] .
+						$egMapsLeafletLayersApiKeys[$layerName] . '"></script>';
+				}
 			}
 		} else {
 			if ( $service === 'openlayers' ) {

--- a/includes/services/Leaflet/Maps_Leaflet.php
+++ b/includes/services/Leaflet/Maps_Leaflet.php
@@ -38,11 +38,13 @@ class MapsLeaflet extends MapsMappingService {
 			'message' => 'maps-leaflet-par-defzoom'
 		];
 
-		$params['layer'] = [
+		$params['layers'] = [
+			'aliases' => 'layer',
 			'type' => 'string',
 			'values' => array_keys( $GLOBALS['egMapsLeafletAvailableLayers'], true, true ),
-			'default' => $GLOBALS['egMapsLeafletLayer'],
+			'default' => $GLOBALS['egMapsLeafletLayers'],
 			'message' => 'maps-leaflet-par-layer',
+			'islist' => true,
 		];
 
 		$params['overlaylayers'] = [

--- a/includes/services/Leaflet/jquery.leaflet.js
+++ b/includes/services/Leaflet/jquery.leaflet.js
@@ -267,20 +267,30 @@
 			this.map = map;
 
 			// add an OpenStreetMap tile layer
-			var layerOptions = {
-				attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-			};
-			if (options.layer === 'OpenStreetMap') {
-				new L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', layerOptions).addTo(map);
-			} else if (options.layer === 'MapQuestOpen') {
-				new MQ.TileLayer(layerOptions).addTo(map);
-			} else {
-				new L.tileLayer.provider(options.layer, layerOptions).addTo(map);
-			}
-
-			$.each(options.overlaylayers, function(index, overlaylayer) {
-				L.tileLayer.provider(overlaylayer).addTo(_this.map);
+			var layers = {};
+			$.each(options.layers.reverse(), function(index, layerName) {
+				var layer = null;
+				var layerOptions = {
+					attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+				};
+				if (layerName === 'OpenStreetMap') {
+					layer = new L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', layerOptions).addTo(map);
+				} else if (layerName === 'MapQuestOpen') {
+					layer = new MQ.TileLayer(layerOptions).addTo(map);
+				} else {
+					layer = new L.tileLayer.provider(layerName, layerOptions).addTo(map);
+				}
+				layers[layerName] = layer;
 			});
+
+			var overlaylayers = {};
+			$.each(options.overlaylayers, function(index, overlaylayerName) {
+				overlaylayers[overlaylayerName] = new L.tileLayer.provider(overlaylayerName).addTo(_this.map);
+			});
+
+			if (options.layers.length > 1) {
+				L.control.layers(layers, overlaylayers).addTo(map);
+			}
 
 			if (options.resizable) {
 				//TODO: Fix moving map when resized
@@ -360,7 +370,7 @@
 
 		this.getDependencies = function ( options ) {
 			var dependencies = [];
-			if (options.layer !== 'OpenStreetMap' || options.overlaylayers.length > 0) {
+			if (options.layers !== ['OpenStreetMap'] || options.overlaylayers.length > 0) {
 				dependencies.push( 'ext.maps.leaflet.providers' );
 			}
 			if (options.enablefullscreen) {


### PR DESCRIPTION
fixes #387 // cc @krabina 

Adds support for multiple layers with leaflet. Displays layer controls like [this leaflet example](http://leafletjs.com/examples/layers-control/).

Only displays `L.control.layers` when there is more than one baselayer, control doesn't show up if there is for example a baselayer and an overlaylayer. overlaylayer are nevertheless included in the control. Should the default behavior be different? I could display the control once there is at least another baselayer or an overlaylayer. And should there be an extra option, like `forceLayerControl` (makes sense for the current default), `hideLayerControl` (usefull for the other default I just described)?

@JeroenDeDauw Did I do the aliasing of `layer` / `layers` correctly? I'm not quite sure about the `egMapsLeafletLayer` option, should I remove it?