### PR TITLE
Allow to configure geocoder cache expiry

### DIFF
--- a/Maps_Settings.php
+++ b/Maps_Settings.php
@@ -63,6 +63,9 @@
 
 	// Boolean. Sets if geocoded addresses should be stored in a cache.
 	$GLOBALS['egMapsEnableGeoCache'] = true;
+	// Integer. If egMapsEnableGeoCache is true, determines the TTL of cached geocoded addresses.
+	// Default value: 1 day.
+	$GLOBALS['egMapsGeoCacheTtl'] = BagOStuff::TTL_DAY;
 
 
 // Coordinate configuration

--- a/src/Geocoders/CachingGeocoder.php
+++ b/src/Geocoders/CachingGeocoder.php
@@ -16,10 +16,12 @@ class CachingGeocoder implements Geocoder {
 
 	private $geocoder;
 	private $cache;
+	private $cacheTtl;
 
-	public function __construct( Geocoder $geocoder, BagOStuff $cache ) {
+	public function __construct( Geocoder $geocoder, BagOStuff $cache, int $cacheTtl ) {
 		$this->geocoder = $geocoder;
 		$this->cache = $cache;
+		$this->cacheTtl = $cacheTtl;
 	}
 
 	/**
@@ -34,7 +36,7 @@ class CachingGeocoder implements Geocoder {
 		if ( $coordinates === false ) {
 			$coordinates = $this->geocoder->geocode( $address );
 
-			$this->cache->set( $key, $coordinates, BagOStuff::TTL_DAY );
+			$this->cache->set( $key, $coordinates, $this->cacheTtl );
 		}
 
 		return $coordinates;

--- a/src/MapsFactory.php
+++ b/src/MapsFactory.php
@@ -37,7 +37,8 @@ class MapsFactory {
 		if ( $this->settings['egMapsEnableGeoCache'] ) {
 			return new CachingGeocoder(
 				$geocoder,
-				$this->getMediaWikiCache()
+				$this->getMediaWikiCache(),
+				$this->settings['egMapsGeoCacheTtl']
 			);
 		}
 


### PR DESCRIPTION
**Problem**
The Google geocoder has a hard limit of 2500 requests / day. Depending on volume, administrators might want to tune the cache TTL of cached geocoded addresses, to avoid hitting the rate limit of this service.

**Solution**
Make the cache TTL of cached geocoded addresses optionally configurable, with the default value being the current hardcoded TTL (1 day).