### PR TITLE
Change signature of MapsMappingService::addDependencies

### DIFF
--- a/includes/Maps_DisplayMapRenderer.php
+++ b/includes/Maps_DisplayMapRenderer.php
@@ -48,8 +48,10 @@ class MapsDisplayMapRenderer {
 			self::getLayerDependencies( $params['mappingservice'], $params )
 		);
 
-		$this->service->addDependencies( $parser );
-		$parser->getOutput()->addHeadItem( $configVars );
+		$parserOutput = $parser->getOutput();
+
+		$this->service->addDependencies( $parserOutput );
+		$parserOutput->addHeadItem( $configVars );
 
 		return $output;
 	}

--- a/includes/Maps_MappingService.php
+++ b/includes/Maps_MappingService.php
@@ -78,25 +78,18 @@ abstract class MapsMappingService {
 	}
 
 	/**
-	 * @since 0.6.3
+	 * @since 5.2.0
+	 * @param ParserOutput $parserOutput
 	 */
-	public final function addDependencies( &$parserOrOut ) {
+	public final function addDependencies( ParserOutput $parserOutput ) {
 		$dependencies = $this->getDependencyHtml();
 
 		// Only add a head item when there are dependencies.
-		if ( $parserOrOut instanceof Parser ) {
-			if ( $dependencies ) {
-				$parserOrOut->getOutput()->addHeadItem( $dependencies );
-			}
-
-			$parserOrOut->getOutput()->addModules( $this->getResourceModules() );
-		} elseif ( $parserOrOut instanceof OutputPage ) {
-			if ( $dependencies !== false ) {
-				$parserOrOut->addHeadItem( md5( $dependencies ), $dependencies );
-			}
-
-			$parserOrOut->addModules( $this->getResourceModules() );
+		if ( $dependencies ) {
+			$parserOutput->addHeadItem( $dependencies );
 		}
+
+		$parserOutput->addModules( $this->getResourceModules() );
 	}
 
 	/**
@@ -106,7 +99,7 @@ abstract class MapsMappingService {
 		$allDependencies = array_merge( $this->getDependencies(), $this->dependencies );
 		$dependencies = [];
 
-		// Only add dependnecies that have not yet been added.
+		// Only add dependencies that have not yet been added.
 		foreach ( $allDependencies as $dependency ) {
 			if ( !in_array( $dependency, $this->addedDependencies ) ) {
 				$dependencies[] = $dependency;


### PR DESCRIPTION
It seems this method is only called in https://github.com/JeroenDeDauw/Maps/blob/master/includes/Maps_DisplayMapRenderer.php#L51 so it only ever gets called with a `Parser` instance.

I'm not sure how public this API is but none of the extensions listed [here](https://www.mediawiki.org/wiki/Extension:Maps#See_also) seem to be using it and historical precedent such as #215 only refers to Semantic Maps as a potential blocker, but SM is now assimilated.