### PR TITLE
Re-arrange order of available mapping services

### DIFF
--- a/Maps_Settings.php
+++ b/Maps_Settings.php
@@ -14,9 +14,9 @@
 
 	// Array of String. Array containing all the mapping services that will be made available to the user.
 	$GLOBALS['egMapsAvailableServices'] = [
-		'googlemaps3',
-		'openlayers',
 		'leaflet',
+		'openlayers',
+		'googlemaps3'
 	];
 
 	// String. The default mapping service, which will be used when no default


### PR DESCRIPTION
Since `egMapsDefaultServices` defaults to the first service defined with `egMapsAvailableServices` if no service is enabled or an invalid service was provided by the user we should have a service here that is freely usable and does not require extra setup to be functional.