### PR TITLE
Make tests compatible with PHPUnit 4 and 6

### DIFF
--- a/tests/Integration/parsers/DistanceParserTest.php
+++ b/tests/Integration/parsers/DistanceParserTest.php
@@ -4,6 +4,7 @@ namespace Maps\Test;
 
 use Maps\DistanceParser;
 use PHPUnit\Framework\TestCase;
+use PHPUnit4And6Compat;
 use ValueParsers\ParseException;
 
 /**
@@ -12,6 +13,7 @@ use ValueParsers\ParseException;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class DistanceParserTest extends TestCase {
+	use PHPUnit4And6Compat;
 
 	/**
 	 * @dataProvider validInputProvider
@@ -42,7 +44,7 @@ class DistanceParserTest extends TestCase {
 	public function testGivenInvalidInput_exceptionIsThrown( $input ) {
 		$parser = new DistanceParser();
 
-		$this->expectException( ParseException::class );
+		$this->setExpectedException( ParseException::class );
 		$parser->parse( $input );
 	}
 

--- a/tests/Integration/parsers/WmsOverlayParserTest.php
+++ b/tests/Integration/parsers/WmsOverlayParserTest.php
@@ -5,6 +5,7 @@ namespace Maps\Test;
 use Maps\Elements\WmsOverlay;
 use Maps\WmsOverlayParser;
 use PHPUnit\Framework\TestCase;
+use PHPUnit4And6Compat;
 use ValueParsers\ParseException;
 
 /**
@@ -13,6 +14,7 @@ use ValueParsers\ParseException;
  * @author Mathias Mølster Lidal <mathiaslidal@gmail.com>
  */
 class WmsOverlayParserTest extends TestCase {
+	use PHPUnit4And6Compat;
 
 	public function testGivenValidInput_parserReturnsOverlayObject() {
 		$parser = new WmsOverlayParser();
@@ -46,7 +48,7 @@ class WmsOverlayParserTest extends TestCase {
 	public function testWhenThereAreLessThanTwoSegments_parseExceptionIsThrown() {
 		$parser = new WmsOverlayParser();
 
-		$this->expectException( ParseException::class );
+		$this->setExpectedException( ParseException::class );
 		$parser->parse( 'Such' );
 	}
 

--- a/tests/Unit/Elements/BaseElementTest.php
+++ b/tests/Unit/Elements/BaseElementTest.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 use Maps\Element;
 use Maps\ElementOptions;
 use PHPUnit\Framework\TestCase;
+use PHPUnit4And6Compat;
 
 /**
  * Base class for unit tests classes for the Maps\BaseElement deriving objects.
@@ -16,6 +17,7 @@ use PHPUnit\Framework\TestCase;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 abstract class BaseElementTest extends TestCase {
+	use PHPUnit4And6Compat;
 
 	public function invalidConstructorProvider() {
 		return [];
@@ -78,7 +80,7 @@ abstract class BaseElementTest extends TestCase {
 	 * @since 3.0
 	 */
 	public function testGivenInvalidArguments_constructorThrowsException() {
-		$this->expectException( InvalidArgumentException::class );
+		$this->setExpectedException( InvalidArgumentException::class );
 		call_user_func_array( [ $this, 'newInstance' ], func_get_args() );
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,4 +15,11 @@ if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 	die( 'You need to install this package with Composer before you can run the tests' );
 }
 
+// If testing against an older version of MediaWiki, define
+// an empty trait to avoid fatal errors.
+if ( !trait_exists( PHPUnit4And6Compat::class ) ) {
+	trait PHPUnit4And6Compat {
+	}
+}
+
 require __DIR__ . '/../vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,12 @@
 <?php
 
+// If testing against an older version of MediaWiki, define
+// an empty trait to avoid fatal errors.
+if ( !trait_exists( PHPUnit4And6Compat::class ) ) {
+	trait PHPUnit4And6Compat {
+	}
+}
+
 if ( defined( 'MEDIAWIKI' ) ) {
 	return;
 }
@@ -13,13 +20,6 @@ ini_set( 'display_errors', 1 );
 
 if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 	die( 'You need to install this package with Composer before you can run the tests' );
-}
-
-// If testing against an older version of MediaWiki, define
-// an empty trait to avoid fatal errors.
-if ( !trait_exists( PHPUnit4And6Compat::class ) ) {
-	trait PHPUnit4And6Compat {
-	}
 }
 
 require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Use the PHPUnit4And6Compat trait from MediaWiki core to make PHPUnit 4
methods work even when being run with PHPUnit 6. If it's being run with
an older MediaWiki core version, define a empty trait in the bootstrap
to avoid fatal errors. Since the lack of the trait means we're running
with PHPUnit 4, everything should work out.