### PR TITLE
Remove use of deprecated wgStyleVersion

### DIFF
--- a/Maps.php
+++ b/Maps.php
@@ -93,7 +93,7 @@ $GLOBALS['wgExtensionFunctions'][] = function() {
 		'license-name' => 'GPL-2.0-or-later'
 	];
 
-	$GLOBALS['egMapsStyleVersion'] = $GLOBALS['wgStyleVersion'] . '-' . Maps_VERSION;
+	$GLOBALS['egMapsStyleVersion'] = '1-' . Maps_VERSION;
 
 	$GLOBALS['wgResourceModules'] = array_merge( $GLOBALS['wgResourceModules'], include 'Maps.resources.php' );
 


### PR DESCRIPTION
I couldn't find any use of egMapsStyleVersion, but to keep this commit simple,
I kept that variable and only removed the use of wgStyleVersion. Also, in case
something depends on its format I've substituted it with the number 1.

This way any use of it will still work and still invalidate cache if the Maps_VERSION
constant is changed.

Ref <https://phabricator.wikimedia.org/T181318>