### PR TITLE
change providers options and global options order

### DIFF
--- a/includes/services/Leaflet/leaflet-providers/leaflet-providers.js
+++ b/includes/services/Leaflet/leaflet-providers/leaflet-providers.js
@@ -83,7 +83,7 @@
 			provider.options.attribution = attributionReplacer(provider.options.attribution);
 
 			// Compute final options combining provider options with any user overrides
-			var layerOpts = L.Util.extend({}, provider.options, options);
+			var layerOpts = L.Util.extend({}, options, provider.options);
 			L.TileLayer.prototype.initialize.call(this, provider.url, layerOpts);
 		}
 	});


### PR DESCRIPTION
In leaflet-providers.js, layerOptions and global options are merged in a wrong order so that OSM attribution allways appear as the layer attribution whatever provider is used.

This PR simply inverts the options order. As a consequence, the right layer attribution appears on the map.

![scotland-att](https://user-images.githubusercontent.com/8211614/41203625-30dfdf52-6cda-11e8-9ed5-87ad1bf3a26c.PNG)
