### PR TITLE
Adding some Geoportail France Maps

### DIFF
--- a/Maps_Settings.php
+++ b/Maps_Settings.php
@@ -14,9 +14,9 @@
 
 	// Array of String. Array containing all the mapping services that will be made available to the user.
 	$GLOBALS['egMapsAvailableServices'] = [
-		'leaflet',
+		'googlemaps3',
 		'openlayers',
-		'googlemaps3'
+		'leaflet',
 	];
 
 	// String. The default mapping service, which will be used when no default
@@ -51,12 +51,10 @@
 
 // Geocoding
 
-	// Sets which service should be used to turn addresses into coordinates
+	// String. The name of the geocoding service to use.
 	// Available services: geonames, google, nominatim
-	// The geonames service requires you to specify a geonames user (see below),
-	// if you set this setting to geonames but do not specify the user, Maps will
-	// fall back to using the google service.
-	$GLOBALS['egMapsDefaultGeoService'] = 'nominatim';
+	// Some services might require you to provide credentials, see the settings below.
+	$GLOBALS['egMapsDefaultGeoService'] = 'geonames';
 
 	// String. GeoNames API user/application name.
 	// Obtain an account here: http://www.geonames.org/login
@@ -65,9 +63,6 @@
 
 	// Boolean. Sets if geocoded addresses should be stored in a cache.
 	$GLOBALS['egMapsEnableGeoCache'] = true;
-	// Integer. If egMapsEnableGeoCache is true, determines the TTL of cached geocoded addresses.
-	// Default value: 1 day.
-	$GLOBALS['egMapsGeoCacheTtl'] = 24 * 3600;
 
 
 // Coordinate configuration
@@ -142,6 +137,9 @@
 		'width'  => [ 50, 1020, 1, 100 ],
 		'height' => [ 50, 1000, 1, 100 ],
 	];
+
+	// String. The default centre for maps. Can be either a set of coordinates or an address.
+	$GLOBALS['egMapsDefaultMapCentre'] = '0, 0';
 
 	// Strings. The default content for all pop-ups. This value will only be used
 	// when the user does not provide one.
@@ -320,8 +318,6 @@
 		// used when the user does not provide one.
 		$GLOBALS['egMapsLeafletLayer'] = 'OpenStreetMap';
 
-		$GLOBALS['egMapsLeafletLayers'] = [ $GLOBALS['egMapsLeafletLayer'] ];
-
 		$GLOBALS['egMapsLeafletOverlayLayers'] = [
 
 		];
@@ -386,7 +382,11 @@
 			'NASAGIBS.ModisTerraTrueColorCR' => true,
 			'NASAGIBS.ModisTerraBands367CR' => true,
 			'NASAGIBS.ViirsEarthAtNight2012' => true,
-			'NLS' => true
+			'NLS' => true,
+			'GeoportailFrance' => true,
+			'GeoportailFrance.parcels' => true,
+			'GeoportailFrance.ign_maps' => true,
+			'GeoportailFrance.orthos' => true
 		];
 
 		$GLOBALS['egMapsLeafletAvailableOverlayLayers'] = [
@@ -412,7 +412,7 @@
 
 		$GLOBALS['egMapsLeafletLayersApiKeys'] = [
 			'MapBox' => '',
-			'MapQuestOpen' => '',
+			'MapQuestOpen' => ''
 		];
 
 		// Layer dependencies

--- a/Maps_Settings.php
+++ b/Maps_Settings.php
@@ -14,9 +14,9 @@
 
 	// Array of String. Array containing all the mapping services that will be made available to the user.
 	$GLOBALS['egMapsAvailableServices'] = [
-		'googlemaps3',
-		'openlayers',
 		'leaflet',
+		'openlayers',
+		'googlemaps3'
 	];
 
 	// String. The default mapping service, which will be used when no default
@@ -51,10 +51,12 @@
 
 // Geocoding
 
-	// String. The name of the geocoding service to use.
+	// Sets which service should be used to turn addresses into coordinates
 	// Available services: geonames, google, nominatim
-	// Some services might require you to provide credentials, see the settings below.
-	$GLOBALS['egMapsDefaultGeoService'] = 'geonames';
+	// The geonames service requires you to specify a geonames user (see below),
+	// if you set this setting to geonames but do not specify the user, Maps will
+	// fall back to using the google service.
+	$GLOBALS['egMapsDefaultGeoService'] = 'nominatim';
 
 	// String. GeoNames API user/application name.
 	// Obtain an account here: http://www.geonames.org/login
@@ -63,6 +65,9 @@
 
 	// Boolean. Sets if geocoded addresses should be stored in a cache.
 	$GLOBALS['egMapsEnableGeoCache'] = true;
+	// Integer. If egMapsEnableGeoCache is true, determines the TTL of cached geocoded addresses.
+	// Default value: 1 day.
+	$GLOBALS['egMapsGeoCacheTtl'] = 24 * 3600;
 
 
 // Coordinate configuration
@@ -137,9 +142,6 @@
 		'width'  => [ 50, 1020, 1, 100 ],
 		'height' => [ 50, 1000, 1, 100 ],
 	];
-
-	// String. The default centre for maps. Can be either a set of coordinates or an address.
-	$GLOBALS['egMapsDefaultMapCentre'] = '0, 0';
 
 	// Strings. The default content for all pop-ups. This value will only be used
 	// when the user does not provide one.
@@ -318,6 +320,8 @@
 		// used when the user does not provide one.
 		$GLOBALS['egMapsLeafletLayer'] = 'OpenStreetMap';
 
+		$GLOBALS['egMapsLeafletLayers'] = [ $GLOBALS['egMapsLeafletLayer'] ];
+
 		$GLOBALS['egMapsLeafletOverlayLayers'] = [
 
 		];
@@ -412,7 +416,7 @@
 
 		$GLOBALS['egMapsLeafletLayersApiKeys'] = [
 			'MapBox' => '',
-			'MapQuestOpen' => ''
+			'MapQuestOpen' => '',
 		];
 
 		// Layer dependencies

--- a/includes/services/Leaflet/leaflet-providers/leaflet-providers.js
+++ b/includes/services/Leaflet/leaflet-providers/leaflet-providers.js
@@ -83,7 +83,7 @@
 			provider.options.attribution = attributionReplacer(provider.options.attribution);
 
 			// Compute final options combining provider options with any user overrides
-			var layerOpts = L.Util.extend({}, provider.options, options);
+			var layerOpts = L.Util.extend({}, options, provider.options);
 			L.TileLayer.prototype.initialize.call(this, provider.url, layerOpts);
 		}
 	});
@@ -628,7 +628,38 @@
 				maxZoom: 18,
 				subdomains: '0123',
 			}
-		}
+		},
+        GeoportailFrance: {
+			url: '//wxs.ign.fr/{apikey}/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT={format}&LAYER={variant}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
+			options: {
+				attribution: '<a target="_blank" href="https://www.geoportail.gouv.fr/">Geoportail France</a>',
+				bounds: [[-75, -180], [81, 180]],
+				minZoom: 2,
+				maxZoom: 18,
+                // Get your own geoportail apikey here : http://professionnels.ign.fr/ign/contrats/ 
+                // NB : 'choisirgeoportail' is a demonstration key that comes with no guarantee
+                apikey: 'choisirgeoportail',
+                format: 'image/jpeg',
+                variant: 'GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN-EXPRESS.STANDARD'
+			},
+			variants: {
+				parcels: {
+                    options : {
+                        variant: 'CADASTRALPARCELS.PARCELS',
+				        maxZoom: 20,
+                        format: 'image/png'
+                    }
+                },
+				ign_maps: 'GEOGRAPHICALGRIDSYSTEMS.MAPS',
+				maps: 'GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN-EXPRESS.STANDARD',
+				orthos: {
+					options: {
+						maxZoom: 19,
+						variant: 'ORTHOIMAGERY.ORTHOPHOTOS'
+					}
+				}
+			}
+        }
 	};
 
 	L.tileLayer.provider = function (provider, options) {


### PR DESCRIPTION
This PR adds the possibility to display French Geoportal Maps to Maps extension with leaflet provider.
Four maps types are added : 

- GeoportailFrance, 
- GeoportailFrance.orthos,
- GeoportailFrance.parcels,
- GeoportailFrance.ign_maps

Note that Geoportal Maps need an access key to be displayed. This PR uses a default public key that can be used as is but comes with no guarantee. 

Exemples : 

```
{{#display_map: 
 |layer=GeoportailFrance
 |service=leaflet
}}
```


![gpmaps](https://user-images.githubusercontent.com/8211614/41206551-ff613602-6d05-11e8-8944-d83040af6e2f.PNG)

```
{{#display_map: 
 |layer=GeoportailFrance.orthos
 |service=leaflet
}}

```

![gporthos](https://user-images.githubusercontent.com/8211614/41206552-06f2caac-6d06-11e8-908b-64f521152a19.PNG)

```
{{#display_map: 
 |layer=GeoportailFrance.parcels
 |service=leaflet
}}

```

![gpparcels](https://user-images.githubusercontent.com/8211614/41206555-095f69f8-6d06-11e8-8185-d8ab7affbae5.PNG)

```
{{#display_map: 
 |layer=GeoportailFrance.ign_maps
 |service=leaflet
}}

```

![ignmaps](https://user-images.githubusercontent.com/8211614/41206557-11181e7e-6d06-11e8-96ea-f01e5a8a49a4.PNG)

