### PR TITLE
Adds some leaflet providers apikey configuration to Maps_Settings.php

### DIFF
--- a/Maps.hooks.php
+++ b/Maps.hooks.php
@@ -54,6 +54,7 @@ final class MapsHooks {
 
 		$vars['egMapsDebugJS'] = $GLOBALS['egMapsDebugJS'];
 		$vars['egMapsAvailableServices'] = $GLOBALS['egMapsAvailableServices'];
+		$vars['egMapsLeafletLayersApiKeys'] = $GLOBALS['egMapsLeafletLayersApiKeys'];
 
 		$vars += $egMapsGlobalJSVars;
 

--- a/Maps_Settings.php
+++ b/Maps_Settings.php
@@ -404,6 +404,8 @@
 		$GLOBALS['egMapsLeafletLayersApiKeys'] = [
 			'MapBox' => '',
 			'MapQuestOpen' => '',
+			'Thunderforest' => '',
+			'GeoportailFrance' => ''
 		];
 
 		// Layer dependencies

--- a/includes/services/Leaflet/jquery.leaflet.js
+++ b/includes/services/Leaflet/jquery.leaflet.js
@@ -12,6 +12,7 @@
 		this.options = options;
 		this.markers = [];
 		this.markercluster = null;
+		var apikeys = mw.config.get('egMapsLeafletLayersApiKeys') ;
 
 		/**
 		 * array point of all map elements (markers, lines, polygons, etc.)
@@ -63,7 +64,7 @@
 		 * and returns it.
 		 * @param {Object} markerData Contains the fields lat, lon, title, text and icon
 		 * @return {L.Marker}
-         */
+		 */
 		this.addMarker = function (properties) {
 			var marker = this.createMarker(properties);
 			if (!this.options.markercluster) {
@@ -299,10 +300,15 @@
 
 			var layers = {};
 			$.each(options.layers.reverse(), function(index, layerName) {
+				var options = {} ;
+				var providerName = layerName.split('.')[0] ;
+				if (apikeys.hasOwnProperty(providerName) && apikeys[providerName] !== '') {
+					options.apikey = apikeys[providerName] ;
+				} 
 				if (layerName === 'MapQuestOpen') {
 					layers[layerName] = new MQ.TileLayer().addTo(map);
 				} else {
-					layers[layerName] = new L.tileLayer.provider(layerName).addTo(map);
+					layers[layerName] = new L.tileLayer.provider(layerName,options).addTo(map);
 				}
 			});
 


### PR DESCRIPTION
This PR adds the ability to configure apikeys for leaflet-providers layers into Maps_Settings.php

             ```
   $GLOBALS['egMapsLeafletLayersApiKeys'] = [
                        'MapBox' => '',
                        'MapQuestOpen' => '',
                        'Thunderforest' => '<insert Thunderforest France API Key here>',
                        'GeoportailFrance' => '<insert Geoportail France API Key here>'
                ];
```

This works with providers that have an `apikey` option into their configurations objects into leaflet-providers. Eg. Thunderforest (not tested)  or GeoportailFrance (tested)

