### PR TITLE
add missing use statement "Maps\MediaWiki\Specials\MapEditorHtml"

### DIFF
--- a/src/MediaWiki/Specials/SpecialMapEditor.php
+++ b/src/MediaWiki/Specials/SpecialMapEditor.php
@@ -3,7 +3,7 @@
 namespace Maps\MediaWiki\Specials;
 
 use Maps\GoogleMapsService;
-use Maps\MediaWiki\Specials;
+use Maps\MediaWiki\Specials\MapEditorHtml;
 use SpecialPage;
 
 /**


### PR DESCRIPTION
Fixes "Error from line 48 of /srv/mediawiki/w/extensions/Maps/src/MediaWiki/Specials/SpecialMapEditor.php: Class 'Maps\MediaWiki\Specials\MapEditorHtml' not found"