### PR TITLE
Remove pagelinktext param from KML format

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,10 @@ different releases and which versions of PHP and MediaWiki they support, see the
 [platform compatibility tables](INSTALL.md#platform-compatibility-and-release-status).
 
 
+## Maps 7.3.0
+
+* Removed long broken `pagelinktext` option from KML result format
+
 ## Maps 7.2.0
 
 Released on March 5th, 2019.

--- a/src/SemanticMW/ResultPrinters/KmlPrinter.php
+++ b/src/SemanticMW/ResultPrinters/KmlPrinter.php
@@ -32,7 +32,6 @@ class KmlPrinter extends FileExportPrinter {
 		$queryHandler->setText( $this->params['text'] );
 		$queryHandler->setTitle( $this->params['title'] );
 		$queryHandler->setSubjectSeparator( '' );
-		$queryHandler->setPageLinkText( $this->params['pagelinktext'] );
 
 		$formatter = new KmlFormatter();
 		return $formatter->formatLocationsAsKml( ...$queryHandler->getLocations() );
@@ -48,7 +47,6 @@ class KmlPrinter extends FileExportPrinter {
 		);
 		$link->setParameter( 'kml', 'format' );
 		$link->setParameter( $this->params['linkabsolute'] ? 'yes' : 'no', 'linkabsolute' );
-		$link->setParameter( $this->params['pagelinktext'], 'pagelinktext' );
 
 		if ( $this->params['title'] !== '' ) {
 			$link->setParameter( $this->params['title'], 'title' );
@@ -102,11 +100,6 @@ class KmlPrinter extends FileExportPrinter {
 			'message' => 'semanticmaps-kml-linkabsolute',
 			'type' => 'boolean',
 			'default' => true,
-		];
-
-		$definitions['pagelinktext'] = [
-			'message' => 'semanticmaps-kml-pagelinktext',
-			'default' => wfMessage( 'semanticmaps-default-kml-pagelink' )->text(),
 		];
 
 		return $definitions;

--- a/src/SemanticMW/ResultPrinters/QueryHandler.php
+++ b/src/SemanticMW/ResultPrinters/QueryHandler.php
@@ -39,12 +39,6 @@ class QueryHandler {
 	 */
 	public $title = '';
 
-	/**
-	 * Make a separate link to the title or not?
-	 * @var boolean
-	 */
-	public $titleLinkSeparate = false;
-
 	private $queryResult;
 
 	private $outputMode;
@@ -60,12 +54,6 @@ class QueryHandler {
 	 * @var boolean
 	 */
 	private $linkAbsolute;
-
-	/**
-	 * The text used for the link to the page (if it's created). $1 will be replaced by the page name.
-	 * @var string
-	 */
-	private $pageLinkText = '$1';
 
 	/**
 	 * A separator to use between the subject and properties in the text field.
@@ -149,13 +137,6 @@ class QueryHandler {
 
 	public function setShowSubject( bool $showSubject ) {
 		$this->showSubject = $showSubject;
-	}
-
-	/**
-	 * Sets the text for the link to the page when separate from the title.
-	 */
-	public function setPageLinkText( string $text ) {
-		$this->pageLinkText = $text;
 	}
 
 	public function setLinkStyle( string $link ) {
@@ -276,7 +257,7 @@ class QueryHandler {
 		}
 
 		if ( $this->showArticleLink() ) {
-			if ( !$this->titleLinkSeparate && $this->linkAbsolute ) {
+			if ( $this->linkAbsolute ) {
 				$text = Html::element(
 					'a',
 					[ 'href' => $object->getTitle()->getFullUrl() ],
@@ -293,23 +274,7 @@ class QueryHandler {
 			$text = $this->hideNamespace ? $object->getText() : $object->getTitle()->getFullText();
 		}
 
-		$text = '<b>' . $text . '</b>';
-
-		if ( !$this->titleLinkSeparate ) {
-			return $text;
-		}
-
-		$txt = $object->getTitle()->getText();
-
-		if ( $this->pageLinkText !== '' ) {
-			$txt = str_replace( '$1', $txt, $this->pageLinkText );
-		}
-
-		return $text . Html::element(
-			'a',
-			[ 'href' => $object->getTitle()->getFullUrl() ],
-			$txt
-		);
+		return '<b>' . $text . '</b>';
 	}
 
 	private function showArticleLink() {


### PR DESCRIPTION
This has been broken since at least 2013.
Not clear to me what the desired behavior is, and if anyone
cares about having it.