### PR TITLE
Fix "Call to private method SMWWikiPageValue::getTitle() from context…

### DIFF
--- a/src/SemanticMW/ResultPrinters/QueryHandler.php
+++ b/src/SemanticMW/ResultPrinters/QueryHandler.php
@@ -255,13 +255,15 @@ class QueryHandler {
 		if ( !$this->showSubject ) {
 			return '';
 		}
-
+		
+		$dataItem = $object->getDataItem();
+		
 		if ( $this->showArticleLink() ) {
 			if ( $this->linkAbsolute ) {
 				$text = Html::element(
 					'a',
-					[ 'href' => $object->getTitle()->getFullUrl() ],
-					$this->hideNamespace ? $object->getText() : $object->getTitle()->getFullText()
+					[ 'href' => $dataItem->getTitle()->getFullUrl() ],
+					$this->hideNamespace ? $object->getText() : $dataItem->getTitle()->getFullText()
 				);
 			} else {
 				if ( $this->hideNamespace ) {
@@ -271,7 +273,7 @@ class QueryHandler {
 				}
 			}
 		} else {
-			$text = $this->hideNamespace ? $object->getText() : $object->getTitle()->getFullText();
+			$text = $this->hideNamespace ? $object->getText() : $dataItem->getTitle()->getFullText();
 		}
 
 		return '<b>' . $text . '</b>';
@@ -287,7 +289,7 @@ class QueryHandler {
 	private function handleResultProperty( SMWDataValue $object, SMWPrintRequest $printRequest ): string {
 		if ( $this->hasTemplate() ) {
 			if ( $object instanceof SMWWikiPageValue ) {
-				return $object->getTitle()->getPrefixedText();
+				return $object->getDataItem()->getTitle()->getPrefixedText();
 			}
 
 			return $object->getLongText( SMW_OUTPUT_WIKI, null );


### PR DESCRIPTION
refs: https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3995

https://sandbox.semantic-mediawiki.org/wiki/Maps_using_templates_-_googlemaps

### Stack

```
[660694fde361da84ea849436] /wiki/Maps_using_templates_-_googlemaps Error from line 290 of /var/www/html/sbxsmw/w/extensions/Maps/src/SemanticMW/ResultPrinters/QueryHandler.php: Call to private method SMWWikiPageValue::getTitle() from context 'Maps\SemanticMW\ResultPrinters\QueryHandler'

Backtrace:

#0 /var/www/html/sbxsmw/w/extensions/Maps/src/SemanticMW/ResultPrinters/QueryHandler.php(230): Maps\SemanticMW\ResultPrinters\QueryHandler->handleResultProperty(SMWWikiPageValue, SMW\Query\PrintRequest)
#1 /var/www/html/sbxsmw/w/extensions/Maps/src/SemanticMW/ResultPrinters/QueryHandler.php(165): Maps\SemanticMW\ResultPrinters\QueryHandler->getLocationsAndProperties(array)
#2 /var/www/html/sbxsmw/w/extensions/Maps/src/SemanticMW/ResultPrinters/QueryHandler.php(155): Maps\SemanticMW\ResultPrinters\QueryHandler->handlePageResult(array)
#3 /var/www/html/sbxsmw/w/extensions/Maps/src/SemanticMW/ResultPrinters/MapPrinter.php(265): Maps\SemanticMW\ResultPrinters\QueryHandler->getLocations()
#4 /var/www/html/sbxsmw/w/extensions/Maps/src/SemanticMW/ResultPrinters/MapPrinter.php(205): Maps\SemanticMW\ResultPrinters\MapPrinter->getJsonForLocations(Generator, array, string, string)
#5 /var/www/html/sbxsmw/w/extensions/Maps/src/SemanticMW/ResultPrinters/MapPrinter.php(120): Maps\SemanticMW\ResultPrinters\MapPrinter->handleMarkerData(array, Maps\SemanticMW\ResultPrinters\QueryHandler)
#6 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/src/Query/ResultPrinters/ResultPrinter.php(342): Maps\SemanticMW\ResultPrinters\MapPrinter->getResultText(SMW\Query\QueryResult, integer)
#7 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/src/Query/ResultPrinters/ResultPrinter.php(307): SMW\Query\ResultPrinters\ResultPrinter->buildResult(SMW\Query\QueryResult)
#8 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/includes/query/SMW_QueryProcessor.php(398): SMW\Query\ResultPrinters\ResultPrinter->getResult(SMW\Query\QueryResult, array, integer)
#9 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/src/ParserFunctions/AskParserFunction.php(364): SMWQueryProcessor::getResultFromQuery(SMWQuery, array, integer, integer)
#10 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/src/ParserFunctions/AskParserFunction.php(197): SMW\ParserFunctions\AskParserFunction->doFetchResultsFromFunctionParameters(array, array)
#11 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/src/ParserFunctionFactory.php(402): SMW\ParserFunctions\AskParserFunction->parse(array)
#12 /var/www/html/sbxsmw/w/includes/parser/Parser.php(3528): SMW\ParserFunctionFactory->SMW\{closure}(Parser, string, string, string, string, string, string, string)
#13 /var/www/html/sbxsmw/w/includes/parser/Parser.php(3235): Parser->callParserFunction(PPFrame_DOM, string, array)
#14 /var/www/html/sbxsmw/w/includes/parser/Preprocessor_DOM.php(1285): Parser->braceSubstitution(array, PPFrame_DOM)
#15 /var/www/html/sbxsmw/w/includes/parser/Parser.php(3049): PPFrame_DOM->expand(DOMElement, integer)
#16 /var/www/html/sbxsmw/w/includes/parser/Parser.php(1359): Parser->replaceVariables(string)
#17 /var/www/html/sbxsmw/w/includes/parser/Parser.php(491): Parser->internalParse(string)
#18 /var/www/html/sbxsmw/w/includes/StubObject.php(112): Parser->parse(string, Title, ParserOptions, boolean, boolean, integer)
#19 /var/www/html/sbxsmw/w/includes/StubObject.php(138): StubObject->_call(string, array)
#20 /var/www/html/sbxsmw/w/includes/content/WikitextContent.php(369): StubObject->__call(string, array)
#21 /var/www/html/sbxsmw/w/includes/content/AbstractContent.php(555): WikitextContent->fillParserOutput(Title, integer, ParserOptions, boolean, ParserOutput)
#22 /var/www/html/sbxsmw/w/includes/Revision/RenderedRevision.php(265): AbstractContent->getParserOutput(Title, integer, ParserOptions, boolean)
#23 /var/www/html/sbxsmw/w/includes/Revision/RenderedRevision.php(234): MediaWiki\Revision\RenderedRevision->getSlotParserOutputUncached(WikitextContent, boolean)
#24 /var/www/html/sbxsmw/w/includes/Revision/RevisionRenderer.php(193): MediaWiki\Revision\RenderedRevision->getSlotParserOutput(string)
#25 /var/www/html/sbxsmw/w/includes/Revision/RevisionRenderer.php(142): MediaWiki\Revision\RevisionRenderer->combineSlotOutput(MediaWiki\Revision\RenderedRevision, array)
#26 [internal function]: MediaWiki\Revision\RevisionRenderer->MediaWiki\Revision\{closure}(MediaWiki\Revision\RenderedRevision, array)
#27 /var/www/html/sbxsmw/w/includes/Revision/RenderedRevision.php(197): call_user_func(Closure, MediaWiki\Revision\RenderedRevision, array)
#28 /var/www/html/sbxsmw/w/includes/poolcounter/PoolWorkArticleView.php(194): MediaWiki\Revision\RenderedRevision->getRevisionParserOutput()
#29 /var/www/html/sbxsmw/w/includes/poolcounter/PoolCounterWork.php(123): PoolWorkArticleView->doWork()
#30 /var/www/html/sbxsmw/w/includes/page/Article.php(773): PoolCounterWork->execute()
#31 /var/www/html/sbxsmw/w/includes/actions/ViewAction.php(68): Article->view()
#32 /var/www/html/sbxsmw/w/includes/MediaWiki.php(499): ViewAction->show()
#33 /var/www/html/sbxsmw/w/includes/MediaWiki.php(294): MediaWiki->performAction(Article, Title)
#34 /var/www/html/sbxsmw/w/includes/MediaWiki.php(865): MediaWiki->performRequest()
#35 /var/www/html/sbxsmw/w/includes/MediaWiki.php(515): MediaWiki->main()
#36 /var/www/html/sbxsmw/w/index.php(42): MediaWiki->run()
#37 {main}
```