### PR TITLE
Add "Maps\\MediaWiki\\Api\\Geocode" to wgAutoloadClasses

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -29,6 +29,9 @@
 	"ContentHandlers": {
 		"GeoJson": "Maps\\MediaWiki\\Content\\GeoJsonContentHandler"
 	},
+	"AutoloadClasses": {
+		"Maps\\MediaWiki\\Api\\Geocode": "src/MediaWiki/Api/ApiGeocode.php"
+	},
 	"namespaces": [
 		{
 			"id": 420,


### PR DESCRIPTION
This works around a issue where mediawiki api module class cannot find Maps\\MediaWiki\\Api\\Geocode.

Fixes #552