### PR TITLE
FileUrlFinder: fix marker images not being found in Shared repository

### DIFF
--- a/src/DataAccess/MediaWikiFileUrlFinder.php
+++ b/src/DataAccess/MediaWikiFileUrlFinder.php
@@ -6,6 +6,7 @@ namespace Maps\DataAccess;
 
 use ImagePage;
 use Maps\FileUrlFinder;
+use RepoGroup;
 use Title;
 
 /**
@@ -19,13 +20,12 @@ class MediaWikiFileUrlFinder implements FileUrlFinder {
 
 		$titleWithoutPrefix = $colonPosition === false ? $fileName : substr( $fileName, $colonPosition + 1 );
 
-		$title = Title::newFromText( trim( $titleWithoutPrefix ), NS_FILE );
+		$file = RepoGroup::singleton()->findFile( trim( $titleWithoutPrefix ) );
 
-		if ( $title !== null && $title->exists() ) {
-			return ( new ImagePage( $title ) )->getDisplayedFile()->getURL();
+		if ( $file && $file->exists() ) {
+			return $file->getURL();
 		}
 
 		return trim( $fileName );
 	}
-
 }


### PR DESCRIPTION
Previously MediaWikiFileUrlFinder was checking for the presence of "File:Something.png" page in the local wiki, but this page may be nonexistent for images that are in Wikimedia Commons, etc.

Proper way is to query RepoGroup::findFile() to find the file (it will find files from shared repositories too).