### PR TITLE
Use user from request context

### DIFF
--- a/src/Presentation/WikitextParser.php
+++ b/src/Presentation/WikitextParser.php
@@ -6,6 +6,7 @@ namespace Maps\Presentation;
 
 use Parser;
 use ParserOptions;
+use RequestContext;
 
 class WikitextParser {
 
@@ -23,7 +24,7 @@ class WikitextParser {
 		return $this->parser->parse(
 			$text,
 			$this->parser->getTitle(),
-			new ParserOptions( method_exists( $this->parser, 'getUserIdentity' ) ? $this->parser->getUserIdentity() : $this->parser->getUser() )
+			new ParserOptions( RequestContext::getMain()->getUser() )
 		)->getText();
 	}
 


### PR DESCRIPTION
This fixes #758 for us but it might not be the correct solution.

I find it a bit strange that `Parser::getUserIdentity()` does not check if `Parser::getOptions()` returns null before trying to use its result. (The documentation of `Parser::getOptions()` acknowledges that it can return null.)