### PR TITLE
Replace deprecated wfExpandUrl()

### DIFF
--- a/src/GoogleMapsService.php
+++ b/src/GoogleMapsService.php
@@ -6,6 +6,7 @@ namespace Maps;
 
 use MediaWiki\Html\Html;
 use Maps\Map\MapData;
+use MediaWiki\MediaWikiServices;
 use ParamProcessor\ProcessedParam;
 use ParamProcessor\ProcessingResult;
 
@@ -216,7 +217,8 @@ class GoogleMapsService implements MappingService {
 					array_filter(
 						array_map(
 							function( string $fileName ) {
-								return wfExpandUrl( MapsFunctions::getFileUrl( $fileName ) );
+								return MediaWikiServices::getInstance()->getUrlUtils()->expand(
+									MapsFunctions::getFileUrl( $fileName ) );
 							},
 							$kmlFileNames
 						),


### PR DESCRIPTION
This function was deprecated in 1.39 and hard-deprecated in 1.45. As such, it needs to be replaced by the UrlUtils class equivalent to avoid deprecation warnings, and the global function will likely be removed in the near future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal URL handling implementation to use modern service-based architecture for improved maintainability and consistency with current framework standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->