### PR TITLE
Bump CI cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v21
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v22
 
       - name: Cache Composer cache
         uses: actions/cache@v4


### PR DESCRIPTION
To get newer versions of MW with updated PHPUnit dependency. Current CI fails due to a security issue in older PHPUnit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline cache version identifier from v21 to v22 to align caching across runs.
  * Ensures caches are invalidated and refreshed consistently when pipeline cache version changes.
  * No functional behavior or build logic was altered; this is a cache/versioning maintenance update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->