### PR TITLE
Run CI with composer phpunit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,11 +76,11 @@ jobs:
       - run: composer update
 
       - name: Run PHPUnit
-        run: php tests/phpunit/phpunit.php -c extensions/Maps
+        run: composer phpunit -- -c extensions/Maps
 
       - name: Run PHPUnit with code coverage
         run: |
-          php tests/phpunit/phpunit.php -c extensions/Maps --coverage-clover coverage.xml
+          composer phpunit -- -c extensions/Maps --coverage-clover coverage.xml
           bash <(curl -s https://codecov.io/bash)
 
 


### PR DESCRIPTION
Because MW master no longer has the old entrypoint.