### PR TITLE
Fix "Implicitly marking parameter $fileFetcher as nullable is deprecated"

### DIFF
--- a/src/MapsFactory.php
+++ b/src/MapsFactory.php
@@ -219,7 +219,7 @@ class MapsFactory {
 		return $factory;
 	}
 
-	public function newGeoJsonFetcher( FileFetcher $fileFetcher = null ): GeoJsonFetcher {
+	public function newGeoJsonFetcher( ?FileFetcher $fileFetcher = null ): GeoJsonFetcher {
 		return new GeoJsonFetcher(
 			$fileFetcher ?? $this->getGeoJsonFileFetcher(),
 			$this->mediaWikiServices->getTitleParser(),


### PR DESCRIPTION

> Mar  7 05:34:27 test151 php: PHP Deprecated:  Maps\MapsFactory::newGeoJsonFetcher(): Implicitly marking parameter $fileFetcher as nullable is deprecated, the explicit nullable type must be used instead in /srv/mediawiki/1.45/extensions/Maps/src/MapsFactory.php on line 222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code quality and type safety through enhanced type declarations.

---

**Note:** This release contains primarily internal improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->