### PR TITLE
Add support for marker-color GeoJSON property

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,11 +32,18 @@ minimum requirements are indicated in bold. For a detailed list of changes, see 
 		<td>Future version</td>
 	</tr>
 	<tr>
+		<th>12.1.x</th>
+		<td>7.4 - 8.4</td>
+		<td>1.43 - 1.44</td>
+		<td>4.2 - 6.0</td>
+		<td>Development</td>
+	</tr>
+	<tr>
 		<th>12.0.x</th>
 		<td>7.4 - 8.4</td>
 		<td><strong>1.40</strong> - 1.44</td>
 		<td><strong>4.2</strong> - 6.0</td>
-		<td><strong>Stable release</strong></td>
+		<td>Stable release</td>
 	</tr>
 	<tr>
 		<th>11.0.x</th>

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,12 @@ different releases and which versions of PHP and MediaWiki they support, see the
 [platform compatibility tables](INSTALL.md#platform-compatibility-and-release-status).
 
 
+## Maps 12.1.0
+
+Under development.
+
+* Added support for the `marker-color` GeoJSON property from the [simplestyle spec](https://github.com/mapbox/simplestyle-spec/tree/master/1.1.0)
+
 ## Maps 12.0.0
 
 Released on August 13th, 2025.
@@ -287,7 +293,7 @@ Released on December 9th, 2019.
     * Border color (property key `stroke`)
     * Border width (property key `stroke-width`)
     * Border opacity (property key `stroke-opacity`)
-    * `marker-size`, `marker-symbol` and `marker-color` are not yet supported and will be ignored
+    * `marker-size` and `marker-symbol` are not yet supported and will be ignored
     * Display only, editing in the visual editor is not yet supported
 * Marker clustering now also cluster markers from the GeoJSON layer
 * Marker clustering now also cluster markers dynamically loaded via the `ajaxquery` feature

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Maps",
-	"version": "13.0.0-alpha",
+	"version": "12.1.0-alpha",
 
 	"author": [
 		"[https://EntropyWins.wtf/mediawiki Jeroen De Dauw]",

--- a/resources/leaflet/FeatureBuilder.js
+++ b/resources/leaflet/FeatureBuilder.js
@@ -150,18 +150,26 @@
 					return maps.leaflet.GeoJson.simpleStyleToLeafletPathOptions(feature.properties);
 				},
 				pointToLayer: function(feature, latlng) {
-					markerLayer.addLayer(
-						createMarker(
-							{
-								lat: latlng.lat,
-								lon: latlng.lng,
-								title: feature.properties.title || '',
-								text: maps.leaflet.GeoJson.popupContentFromProperties(feature.properties),
-								icon: ''
-							},
-							options
-						)
+					let marker = createMarker(
+						{
+							lat: latlng.lat,
+							lon: latlng.lng,
+							title: feature.properties.title || '',
+							text: maps.leaflet.GeoJson.popupContentFromProperties(feature.properties),
+							icon: ''
+						},
+						options
 					);
+
+					let color = feature.properties && feature.properties['marker-color'];
+					if (color) {
+						let icon = maps.leaflet.GeoJson.createColoredIcon(L, color);
+						if (icon) {
+							marker.setIcon(icon);
+						}
+					}
+
+					markerLayer.addLayer(marker);
 				},
 				onEachFeature: function (feature, layer) {
 					if (feature.geometry.type !== 'Point') {

--- a/resources/leaflet/GeoJson.js
+++ b/resources/leaflet/GeoJson.js
@@ -49,6 +49,40 @@
 			+ escapeHTML(properties.description || '');
 	};
 
+	GeoJson.createColoredIcon = function(L, color) {
+		if (!/^#?[a-fA-F0-9]{3,6}$/.test(color)) {
+			return null;
+		}
+
+		if (color.charAt(0) !== '#') {
+			color = '#' + color;
+		}
+
+		let svg = '<svg xmlns="http://www.w3.org/2000/svg" width="25" height="41" viewBox="0 0 25 41">'
+			+ '<path d="M12.5 0C5.5 0 0 5.5 0 12.3c0 2.4.7 4.6 1.9 6.5L12.5 41l10.6-22.2c1.2-1.9 1.9-4.1 1.9-6.5C25 5.5 19.5 0 12.5 0z" '
+			+ 'fill="' + color + '" stroke="#333" stroke-width="1"/>'
+			+ '<circle cx="12.5" cy="12.5" r="5" fill="#fff" opacity="0.6"/>'
+			+ '</svg>';
+		return new L.Icon({
+			iconUrl: 'data:image/svg+xml;base64,' + btoa(svg),
+			iconSize: [25, 41],
+			iconAnchor: [12, 41],
+			popupAnchor: [1, -34]
+		});
+	};
+
+	GeoJson.pointToLayer = function(feature, latlng) {
+		let options = {};
+		let color = feature.properties && feature.properties['marker-color'];
+		if (color) {
+			let icon = GeoJson.createColoredIcon(L, color);
+			if (icon) {
+				options.icon = icon;
+			}
+		}
+		return L.marker(latlng, options);
+	};
+
 	GeoJson.newGeoJsonLayer = function(L, json) {
 		return L.geoJSON(
 			json,
@@ -56,6 +90,7 @@
 				style: function (feature) {
 					return GeoJson.simpleStyleToLeafletPathOptions(feature.properties);
 				},
+				pointToLayer: GeoJson.pointToLayer,
 				onEachFeature: function (feature, layer) {
 					let popupContent = GeoJson.popupContentFromProperties(feature.properties);
 					if (popupContent !== '') {

--- a/resources/leaflet/LeafletEditor.js
+++ b/resources/leaflet/LeafletEditor.js
@@ -88,6 +88,7 @@
 					style: function (feature) {
 						return  maps.leaflet.GeoJson.simpleStyleToLeafletPathOptions(feature.properties);
 					},
+					pointToLayer: maps.leaflet.GeoJson.pointToLayer,
 					onEachFeature: self._onEditableFeature
 				}
 			);


### PR DESCRIPTION
- Implements the `marker-color` property from the [simplestyle spec](https://github.com/mapbox/simplestyle-spec/tree/master/1.1.0) for GeoJSON Point features
- Markers with a `marker-color` hex value are rendered as colored SVG pin icons
- Works in `#display_map` GeoJSON embeds, GeoJSON page view, and the visual editor

Closes #848

<img width="827" height="514" alt="image" src="https://github.com/user-attachments/assets/3816b080-1eca-41f0-9e8d-50c0eb48140f" />

also works in the editor: 
<img width="938" height="596" alt="image" src="https://github.com/user-attachments/assets/c80cffde-901c-4068-8ad9-2bd8ea630e8b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the GeoJSON `marker-color` property in point features for customized map markers.

* **Documentation**
  * Updated compatibility information for Maps 12.1.0 with supported PHP (7.4–8.4) and MediaWiki (1.43–1.44) versions.
  * Added Maps 12.1.0 release notes indicating development status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->