### PR TITLE
Use user language instead of content language for UI messages

### DIFF
--- a/src/GeoJsonPages/GeoJsonMapPageUi.php
+++ b/src/GeoJsonPages/GeoJsonMapPageUi.php
@@ -52,7 +52,7 @@ class GeoJsonMapPageUi {
 					[
 						'class' => 'maps-loading-message'
 					],
-					wfMessage( 'maps-loading-map' )->inContentLanguage()->text()
+					wfMessage( 'maps-loading-map' )->text()
 				)
 			)
 		);

--- a/src/GeoJsonPages/GeoJsonNewPageUi.php
+++ b/src/GeoJsonPages/GeoJsonNewPageUi.php
@@ -24,7 +24,7 @@ class GeoJsonNewPageUi {
 				[
 					'id' => 'maps-geojson-new'
 				],
-				wfMessage( 'maps-geo-json-create-page-button' )->inContentLanguage()->text()
+				wfMessage( 'maps-geo-json-create-page-button' )->text()
 			)
 		);
 	}

--- a/src/Map/MapHtmlBuilder.php
+++ b/src/Map/MapHtmlBuilder.php
@@ -31,7 +31,7 @@ class MapHtmlBuilder {
 				[
 					'class' => 'maps-loading-message'
 				],
-				wfMessage( 'maps-loading-map' )->inContentLanguage()->text()
+				wfMessage( 'maps-loading-map' )->text()
 			)
 		);
 	}


### PR DESCRIPTION
## Summary
- Remove `inContentLanguage()` from UI-facing messages so they display in the user's preferred language
- Fixes display for wikis with language variants (e.g. Chinese zh) where users expect UI in their variant
- Affected: `maps-geo-json-create-page-button`, `maps-loading-map` (2 locations)
- Does **not** change SMW data messages (`CoordinateValue`, `KmlPrinter`) where content language is correct

Closes #694

## Test plan
- [x] All 217 Maps tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected language display for loading messages and button labels to use context-appropriate localization instead of enforcing content language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->