### PR TITLE
Remove deprecated ParserOutput::getText() fallback

### DIFF
--- a/src/Presentation/WikitextParser.php
+++ b/src/Presentation/WikitextParser.php
@@ -27,18 +27,11 @@ class WikitextParser {
 			new ParserOptions( $this->parser->getUserIdentity() )
 		);
 
-		if ( method_exists( $parserOutput, 'getContentHolderText' ) ) {
-			try {
-				return $parserOutput->getContentHolderText();
-			} catch ( LogicException $e ) {
-				// Handle case where there is no body content
-				return '';
-			}
-		} elseif ( method_exists( $parserOutput, 'getText' ) ) {
-			return $parserOutput->getText();
+		try {
+			return $parserOutput->getContentHolderText();
+		} catch ( LogicException $e ) {
+			return '';
 		}
-
-		return '';
 	}
 
 }


### PR DESCRIPTION
## Summary
- Remove `method_exists()` check and deprecated `getText()` fallback from `WikitextParser::wikitextToHtml()`
- Since Maps requires MediaWiki >= 1.43, `getContentHolderText()` is always available
- Eliminates deprecation warning on every map render on MW 1.42+

Closes #812

## Test plan
- [x] All 217 Maps tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code structure and simplified logic flow in wikitext parsing functionality to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->