### PR TITLE
Fix Visual Editor crash when maps contain polygons

### DIFF
--- a/src/Presentation/WikitextParser.php
+++ b/src/Presentation/WikitextParser.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace Maps\Presentation;
 
 use LogicException;
+use MediaWiki\Context\RequestContext;
 use MediaWiki\Parser\Parser;
 use ParserOptions;
 
@@ -21,24 +22,22 @@ class WikitextParser {
 			return '';
 		}
 
+		$options = $this->parser->getOptions();
+		if ( $options === null ) {
+			$options = new ParserOptions( RequestContext::getMain()->getUser() );
+		}
+
 		$parserOutput = $this->parser->parse(
 			$text,
 			$this->parser->getTitle(),
-			new ParserOptions( $this->parser->getUserIdentity() )
+			$options
 		);
 
-		if ( method_exists( $parserOutput, 'getContentHolderText' ) ) {
-			try {
-				return $parserOutput->getContentHolderText();
-			} catch ( LogicException $e ) {
-				// Handle case where there is no body content
-				return '';
-			}
-		} elseif ( method_exists( $parserOutput, 'getText' ) ) {
-			return $parserOutput->getText();
+		try {
+			return $parserOutput->getContentHolderText();
+		} catch ( LogicException $e ) {
+			return '';
 		}
-
-		return '';
 	}
 
 }


### PR DESCRIPTION
## Summary
- Fix crash when Visual Editor parses templates containing polygon maps
- The parser clone used in VE context may not have `ParserOptions` set, causing `getUserIdentity()` to fail with "Call to a member function getUserIdentity() on null"
- Fix: reuse the parser's existing options when available, fall back to request context user
- Also removes deprecated `getText()` fallback (since Maps requires MW >= 1.43)

Closes #758
Also fixes #812

## Test plan
- [x] All 217 Maps tests pass
- [ ] CI passes
- [ ] Visual Editor no longer crashes on pages with polygon maps

🤖 Generated with [Claude Code](https://claude.com/claude-code)