### PR TITLE
Fix popup anchor offset for custom marker icons

### DIFF
--- a/resources/leaflet/FeatureBuilder.js
+++ b/resources/leaflet/FeatureBuilder.js
@@ -24,7 +24,7 @@
 					iconUrl: properties.icon,
 					iconSize: [ img.width, img.height ],
 					iconAnchor: [ img.width / 2, img.height ],
-					popupAnchor: [ -img.width % 2, -img.height*2/3 ]
+					popupAnchor: [ -img.width / 2, -img.height*2/3 ]
 				});
 
 				marker.setIcon(icon);


### PR DESCRIPTION
## Summary
- Fix popupAnchor x-coordinate calculation in `FeatureBuilder.js` that used modulus (`%`) instead of division (`/`)
- This caused custom marker icon popups to appear off-center (e.g., 0px offset instead of -32px for a 64px icon)

## Test plan
- [ ] Open a Leaflet map with a custom marker icon that has a popup
- [ ] Verify the popup appears centered above the marker, not shifted to one side
- [ ] Test with icons of various widths to confirm consistent centering

🤖 Generated with [Claude Code](https://claude.com/claude-code)