### PR TITLE
Fix race condition preventing maps-visual-edit tag from being applied

### DIFF
--- a/resources/MapSaver.js
+++ b/resources/MapSaver.js
@@ -27,25 +27,27 @@
 		// parameters.summary: required string
 		// parameters.done: required callback function
 		self.save = function(paremeters) {
-			new mw.Api().edit(
-				pageName,
-				function(revision) {
-					let editApiParameters = {
-						text: paremeters.newContent,
-						summary: paremeters.summary,
-						minor: false
-					};
+			getUserHasPermission(
+				"applychangetags",
+				function(canApplyTags) {
+					new mw.Api().edit(
+						pageName,
+						function(revision) {
+							let editApiParameters = {
+								text: paremeters.newContent,
+								summary: paremeters.summary,
+								minor: false
+							};
 
-					ifUserHasPermission(
-						"applychangetags",
-						function() {
-							editApiParameters.tags = ['maps-visual-edit'];
+							if (canApplyTags) {
+								editApiParameters.tags = ['maps-visual-edit'];
+							}
+
+							return editApiParameters;
 						}
-					);
-
-					return editApiParameters;
+					).then(paremeters.done);
 				}
-			).then(paremeters.done);
+			);
 		};
 
 		return self;


### PR DESCRIPTION
## Summary
- Fixed a race condition in `MapSaver.js` where the `maps-visual-edit` tag was never applied to edits
- The `ifUserHasPermission()` call is async (calls `mw.user.getRights` API), but the edit callback returned its parameters synchronously before the permission check completed
- Moved the permission check to happen before `mw.Api().edit()` is called, so the result is available synchronously inside the edit callback

## Test plan
- [ ] Make a visual map edit as a user with the `applychangetags` permission and verify the `maps-visual-edit` tag appears in the edit's tags (visible in Recent Changes or page history)
- [ ] Make a visual map edit as a user without the `applychangetags` permission and verify no tag error occurs
- [ ] Verify the edit itself still saves correctly (content and summary are applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)