### PR TITLE
Fix SSRF vulnerability in GeoJsonFetcher

### DIFF
--- a/src/DataAccess/GeoJsonFetcher.php
+++ b/src/DataAccess/GeoJsonFetcher.php
@@ -20,11 +20,13 @@ class GeoJsonFetcher {
 	private FileFetcher $fileFetcher;
 	private \TitleParser $titleParser;
 	private RevisionLookup $revisionLookup;
+	private UrlSsrfGuard $ssrfGuard;
 
 	public function __construct( FileFetcher $fileFetcher, \TitleParser $titleParser, RevisionLookup $revisionLookup ) {
 		$this->fileFetcher = $fileFetcher;
 		$this->titleParser = $titleParser;
 		$this->revisionLookup = $revisionLookup;
+		$this->ssrfGuard = new UrlSsrfGuard();
 	}
 
 	public function parse( string $fileLocation ): array {
@@ -58,7 +60,7 @@ class GeoJsonFetcher {
 		}
 
 		// Prevent SSRF by blocking requests to private/reserved IP ranges
-		if ( $this->urlResolvesToPrivateIp( $fileLocation ) ) {
+		if ( $this->ssrfGuard->urlResolvesToPrivateNetwork( $fileLocation ) ) {
 			return $this->newEmptyResult();
 		}
 
@@ -72,35 +74,6 @@ class GeoJsonFetcher {
 		catch ( FileFetchingException $ex ) {
 			return $this->newEmptyResult();
 		}
-	}
-
-	private function urlResolvesToPrivateIp( string $url ): bool {
-		$host = parse_url( $url, PHP_URL_HOST );
-
-		if ( $host === false || $host === null ) {
-			return true;
-		}
-
-		// Strip brackets from IPv6 literals
-		$host = trim( $host, '[]' );
-
-		$ips = gethostbynamel( $host );
-
-		if ( $ips === false ) {
-			// Also check for IPv6 literal addresses
-			if ( filter_var( $host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
-				return !filter_var( $host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE );
-			}
-			return true;
-		}
-
-		foreach ( $ips as $ip ) {
-			if ( !filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	private function newEmptyResult(): GeoJsonFetcherResult {

--- a/src/DataAccess/UrlSsrfGuard.php
+++ b/src/DataAccess/UrlSsrfGuard.php
@@ -1,0 +1,71 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\DataAccess;
+
+use Wikimedia\IPUtils;
+
+/**
+ * Checks whether a URL resolves to a private or reserved IP address.
+ * Used to prevent Server-Side Request Forgery (SSRF) attacks.
+ *
+ * Note: This provides best-effort protection but cannot prevent DNS rebinding
+ * attacks where a hostname returns a public IP during validation but a private
+ * IP during the actual HTTP request. Full protection requires DNS pinning at
+ * the HTTP client level.
+ *
+ * @licence GNU GPL v2+
+ */
+class UrlSsrfGuard {
+
+	/**
+	 * Returns true if the URL's hostname resolves to any private or reserved IP address.
+	 * Also returns true (fail-closed) if the hostname cannot be resolved.
+	 */
+	public function urlResolvesToPrivateNetwork( string $url ): bool {
+		$host = parse_url( $url, PHP_URL_HOST );
+
+		if ( $host === false || $host === null ) {
+			return true;
+		}
+
+		// Strip brackets from IPv6 literals (e.g. [::1])
+		$host = trim( $host, '[]' );
+
+		// Check if the host is an IP literal
+		if ( filter_var( $host, FILTER_VALIDATE_IP ) ) {
+			return !IPUtils::isPublic( $host );
+		}
+
+		// Resolve hostname to IPs (IPv4)
+		$ipv4s = gethostbynamel( $host );
+
+		// Also resolve IPv6 (AAAA records)
+		$ipv6s = [];
+		$aaaaRecords = dns_get_record( $host, DNS_AAAA );
+		if ( is_array( $aaaaRecords ) ) {
+			foreach ( $aaaaRecords as $record ) {
+				if ( isset( $record['ipv6'] ) ) {
+					$ipv6s[] = $record['ipv6'];
+				}
+			}
+		}
+
+		$allIps = array_merge( $ipv4s ?: [], $ipv6s );
+
+		// Fail closed: if no IPs resolved, block the request
+		if ( $allIps === [] ) {
+			return true;
+		}
+
+		foreach ( $allIps as $ip ) {
+			if ( !IPUtils::isPublic( $ip ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/tests/Integration/DataAccess/GeoJsonFetcherTest.php
+++ b/tests/Integration/DataAccess/GeoJsonFetcherTest.php
@@ -119,25 +119,13 @@ class GeoJsonFetcherTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider privateIpUrlProvider
-	 */
-	public function testWhenUrlResolvesToPrivateIp_emptyJsonIsReturned( string $url ) {
+	public function testWhenUrlResolvesToPrivateIp_emptyJsonIsReturned() {
 		$this->fileFetcher = new StubFileFetcher( json_encode( self::VALID_FILE_JSON ) );
 
 		$this->assertSame(
 			[],
-			$this->newJsonFileParser()->parse( $url )
+			$this->newJsonFileParser()->parse( 'http://127.0.0.1/file' )
 		);
-	}
-
-	public static function privateIpUrlProvider(): iterable {
-		yield 'loopback' => [ 'http://127.0.0.1/file' ];
-		yield 'link-local / AWS metadata' => [ 'http://169.254.169.254/latest/meta-data/' ];
-		yield 'private class A' => [ 'http://10.0.0.1/file' ];
-		yield 'private class B' => [ 'http://172.16.0.1/file' ];
-		yield 'private class C' => [ 'http://192.168.1.1/file' ];
-		yield 'localhost' => [ 'http://localhost/file' ];
 	}
 
 }

--- a/tests/Unit/DataAccess/UrlSsrfGuardTest.php
+++ b/tests/Unit/DataAccess/UrlSsrfGuardTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\Unit\DataAccess;
+
+use Maps\DataAccess\UrlSsrfGuard;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Maps\DataAccess\UrlSsrfGuard
+ */
+class UrlSsrfGuardTest extends TestCase {
+
+	private UrlSsrfGuard $guard;
+
+	protected function setUp(): void {
+		$this->guard = new UrlSsrfGuard();
+	}
+
+	/**
+	 * @dataProvider privateIpUrlProvider
+	 */
+	public function testPrivateIpUrlsAreBlocked( string $url ): void {
+		$this->assertTrue(
+			$this->guard->urlResolvesToPrivateNetwork( $url ),
+			"Expected $url to be blocked as private network"
+		);
+	}
+
+	public static function privateIpUrlProvider(): iterable {
+		// IPv4 loopback
+		yield 'loopback' => [ 'http://127.0.0.1/file' ];
+		yield 'loopback other' => [ 'http://127.0.0.2/file' ];
+
+		// AWS metadata / link-local
+		yield 'AWS metadata' => [ 'http://169.254.169.254/latest/meta-data/' ];
+		yield 'link-local' => [ 'http://169.254.1.1/file' ];
+
+		// RFC 1918 private ranges
+		yield 'private 10.x' => [ 'http://10.0.0.1/file' ];
+		yield 'private 10.x high' => [ 'http://10.255.255.255/file' ];
+		yield 'private 172.16.x' => [ 'http://172.16.0.1/file' ];
+		yield 'private 172.31.x' => [ 'http://172.31.255.255/file' ];
+		yield 'private 192.168.x' => [ 'http://192.168.1.1/file' ];
+
+		// "This network" (0.0.0.0/8)
+		yield 'zero address' => [ 'http://0.0.0.0/file' ];
+
+		// IPv6 loopback
+		yield 'IPv6 loopback' => [ 'http://[::1]/file' ];
+
+		// IPv6 private (fc00::/7)
+		yield 'IPv6 ULA' => [ 'http://[fd00::1]/file' ];
+		yield 'IPv6 ULA fc' => [ 'http://[fc00::1]/file' ];
+
+		// IPv6 link-local (fe80::/10)
+		yield 'IPv6 link-local' => [ 'http://[fe80::1]/file' ];
+
+		// Hostname resolving to loopback
+		yield 'localhost' => [ 'http://localhost/file' ];
+	}
+
+	/**
+	 * @dataProvider invalidUrlProvider
+	 */
+	public function testInvalidUrlsAreBlocked( string $url ): void {
+		$this->assertTrue(
+			$this->guard->urlResolvesToPrivateNetwork( $url ),
+			"Expected invalid URL $url to be blocked (fail-closed)"
+		);
+	}
+
+	public static function invalidUrlProvider(): iterable {
+		yield 'no host' => [ 'http://' ];
+		yield 'unresolvable host' => [ 'http://this-domain-does-not-exist-xyzzy.invalid/file' ];
+	}
+
+	public function testPublicIpUrlIsAllowed(): void {
+		// 93.184.216.34 is example.com's well-known public IP
+		$this->assertFalse(
+			$this->guard->urlResolvesToPrivateNetwork( 'http://93.184.216.34/file' ),
+			'Public IP should not be blocked'
+		);
+	}
+
+	public function testPublicHostnameIsAllowed(): void {
+		$this->assertFalse(
+			$this->guard->urlResolvesToPrivateNetwork( 'http://example.com/file' ),
+			'Public hostname should not be blocked'
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Fix Server-Side Request Forgery (SSRF) vulnerability in `GeoJsonFetcher` where the `geojson` parameter accepted arbitrary URLs fetched server-side, allowing wiki editors to reach internal services (e.g., AWS metadata endpoint at `169.254.169.254`)
- Add hostname resolution and IP validation after the existing `FILTER_VALIDATE_URL` check to block private/reserved IP ranges (RFC 1918, link-local, loopback, IPv6 private)
- Add 6 test cases covering loopback, link-local, private class A/B/C, and localhost URLs

## Test plan
- [x] Existing `GeoJsonFetcherTest` tests pass (updated test URLs from unresolvable `such.a` to `example.com`)
- [x] New tests verify that URLs pointing to private IP ranges return empty GeoJSON
- [ ] Manual verification: use `{{#display_map:geojson=http://169.254.169.254/latest/meta-data/}}` and confirm it returns empty content

🤖 Generated with [Claude Code](https://claude.com/claude-code)