### PR TITLE
Fix stored XSS in AJAX marker popups

### DIFF
--- a/resources/semanticMaps.js
+++ b/resources/semanticMaps.js
@@ -63,7 +63,7 @@ window.sm = new ( function( $, mw ) {
 						lat: coordinates.lat,
 						lon: coordinates.lon,
 						title: location.fulltext,
-						text: '<b><a href="' + location.fullurl + '">' + location.fulltext + '</a></b>',
+						text: $('<b/>').append($('<a/>', { href: location.fullurl }).text(location.fulltext))[0].outerHTML,
 						icon: icon
 					};
 


### PR DESCRIPTION
## Summary
- Fix stored XSS vulnerability in `semanticMaps.js` AJAX marker popup construction
- The `ajaxUpdateMarker` function built marker popup HTML by concatenating `location.fulltext` directly into an HTML string, allowing page titles containing script payloads to execute
- Replaced unsafe string concatenation with jQuery DOM construction: `$('<b/>').append($('<a/>', { href: location.fullurl }).text(location.fulltext))[0].outerHTML`

## Test plan
- [x] All 218 Maps tests pass
- [x] CI passes
- [x] Verified XSS payload `<img src=x onerror=alert("XSS")>` fires alert dialog with vulnerable code
- [x] Verified same payload is HTML-escaped with fix (no alert, rendered as literal text)
- [x] Regular `#display_map` markers and popups render correctly with fix in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)