### PR TITLE
Fix LeafletEditor.remove() crash when no edits were made

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -348,6 +348,7 @@
 			"leaflet/GeoJsonTest.js",
 			"leaflet/FeatureBuilderTest.js",
 			"leaflet/JQueryLeafletTest.js",
+			"leaflet/LeafletEditorTest.js",
 			"MapSaverTest.js"
 		],
 		"dependencies": [

--- a/resources/leaflet/LeafletEditor.js
+++ b/resources/leaflet/LeafletEditor.js
@@ -231,7 +231,9 @@
 
 		self.remove = function() {
 			self.drawControl.remove();
-			self.saveButton.remove();
+			if (self.saveButton) {
+				self.saveButton.remove();
+			}
 			self.geoJsonLayer.remove();
 		};
 

--- a/tests/js/leaflet/LeafletEditorTest.js
+++ b/tests/js/leaflet/LeafletEditorTest.js
@@ -1,0 +1,58 @@
+( function () {
+	'use strict';
+
+	QUnit.module( 'Maps.LeafletEditor', {
+		beforeEach: function () {
+			this.$container = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+			this.map = L.map( this.$container[ 0 ], { center: [ 52, 5 ], zoom: 10 } );
+			this.mapSaver = new window.maps.MapSaver( 'TestPage' );
+		},
+		afterEach: function () {
+			this.map.remove();
+		}
+	} );
+
+	QUnit.test( 'remove() does not crash when no edits were made', function ( assert ) {
+		var editor = window.maps.leaflet.LeafletEditor(
+			this.map,
+			this.mapSaver
+		);
+
+		editor.initialize( { type: 'FeatureCollection', features: [] } );
+
+		var layerCountBefore = 0;
+		this.map.eachLayer( function () { layerCountBefore++; } );
+
+		editor.remove();
+
+		var layerCountAfter = 0;
+		this.map.eachLayer( function () { layerCountAfter++; } );
+
+		assert.true( layerCountAfter < layerCountBefore, 'GeoJSON layer was removed from the map' );
+	} );
+
+	QUnit.test( 'remove() cleans up after edits were made', function ( assert ) {
+		var editor = window.maps.leaflet.LeafletEditor(
+			this.map,
+			this.mapSaver
+		);
+
+		editor.initialize( { type: 'FeatureCollection', features: [] } );
+
+		// Simulate a created feature to trigger _showSaveButton
+		this.map.fire( L.Draw.Event.CREATED, {
+			layer: L.marker( [ 52, 5 ] )
+		} );
+
+		var layerCountBefore = 0;
+		this.map.eachLayer( function () { layerCountBefore++; } );
+
+		editor.remove();
+
+		var layerCountAfter = 0;
+		this.map.eachLayer( function () { layerCountAfter++; } );
+
+		assert.true( layerCountAfter < layerCountBefore, 'Layers were removed from the map after edits' );
+	} );
+
+}() );


### PR DESCRIPTION
## Summary
- `LeafletEditor.remove()` calls `self.saveButton.remove()` unconditionally, but `saveButton` is only created after the user makes an edit
- Calling `remove()` before any edits crashes with `TypeError`, preventing cleanup of draw controls and GeoJSON layer
- Fix: add null guard `if (self.saveButton)` before calling `.remove()`

Closes #888

## Test plan
- [x] All 247 PHPUnit tests pass
- [x] QUnit test added: `remove()` without edits completes without error
- [x] QUnit test added: `remove()` after edits completes without error
- [x] Verified bug exists on master (no null guard on line 234)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)