### PR TITLE
Fix PHP 8.4 implicit nullable parameter deprecations

### DIFF
--- a/src/Map/DisplayMap/DisplayMapRenderer.php
+++ b/src/Map/DisplayMap/DisplayMapRenderer.php
@@ -31,7 +31,7 @@ class DisplayMapRenderer {
 	private WikitextParser $wikitextParser;
 	private ElementJsonSerializer $elementSerializer;
 
-	public function __construct( MappingService $service = null ) {
+	public function __construct( ?MappingService $service = null ) {
 		$this->service = $service;
 	}
 

--- a/src/Presentation/MapsDistanceParser.php
+++ b/src/Presentation/MapsDistanceParser.php
@@ -17,14 +17,14 @@ class MapsDistanceParser {
 	private static bool $validatedDistanceUnit = false;
 	private static $unitRegex = false;
 
-	public static function parseAndFormat( string $distance, string $unit = null, int $decimals = 2 ): string {
+	public static function parseAndFormat( string $distance, ?string $unit = null, int $decimals = 2 ): string {
 		return self::formatDistance( self::parseDistance( $distance ), $unit, $decimals );
 	}
 
 	/**
 	 * Formats a given distance in meters to a distance in an optionally specified notation.
 	 */
-	public static function formatDistance( float $meters, string $unit = null, int $decimals = 2 ): string {
+	public static function formatDistance( float $meters, ?string $unit = null, int $decimals = 2 ): string {
 		$meters = MediaWikiServices::getInstance()->getContentLanguage()->formatNum( round( $meters / self::getUnitRatio( $unit ), $decimals ) );
 		return "$meters $unit";
 	}
@@ -32,7 +32,7 @@ class MapsDistanceParser {
 	/**
 	 * Returns the unit to meter ratio in a safe way, by first resolving the unit.
 	 */
-	public static function getUnitRatio( string $unit = null ): float {
+	public static function getUnitRatio( ?string $unit = null ): float {
 		global $egMapsDistanceUnits;
 		return $egMapsDistanceUnits[self::getValidUnit( $unit )];
 	}
@@ -40,7 +40,7 @@ class MapsDistanceParser {
 	/**
 	 * Returns a valid unit. If the provided one is invalid, the default will be used.
 	 */
-	public static function getValidUnit( string $unit = null ): string {
+	public static function getValidUnit( ?string $unit = null ): string {
 		global $egMapsDistanceUnit, $egMapsDistanceUnits;
 
 		// This ensures the value for $egMapsDistanceUnit is correct, and caches the result.

--- a/src/SemanticMW/AreaDescription.php
+++ b/src/SemanticMW/AreaDescription.php
@@ -29,7 +29,7 @@ class AreaDescription extends ValueDescription {
 	private SMWDIGeoCoord $center;
 	private string $radius;
 
-	public function __construct( SMWDataItem $areaCenter, int $comparator, string $radius, DIProperty $property = null ) {
+	public function __construct( SMWDataItem $areaCenter, int $comparator, string $radius, ?DIProperty $property = null ) {
 		if ( !( $areaCenter instanceof SMWDIGeoCoord ) ) {
 			throw new InvalidArgumentException( '$areaCenter needs to be a SMWDIGeoCoord' );
 		}

--- a/src/SemanticMW/CoordinateValue.php
+++ b/src/SemanticMW/CoordinateValue.php
@@ -160,7 +160,7 @@ class CoordinateValue extends SMWDataValue {
 	 *
 	 * @return string|null
 	 */
-	private function getFormattedCoord( SMWDIGeoCoord $dataItem, string $format = null ) {
+	private function getFormattedCoord( SMWDIGeoCoord $dataItem, ?string $format = null ) {
 		return MapsFactory::globalInstance()->getCoordinateFormatter()->format(
 			new LatLongValue(
 				$dataItem->getLatitude(),


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/Maps/issues/890

PHP 8.4 deprecates implicitly marking a parameter as nullable by giving it a default value of null without an explicit nullable type. Add the explicit `?` prefix to the affected parameters:

- `MapsDistanceParser::parseAndFormat`
- `MapsDistanceParser::formatDistance`
- `MapsDistanceParser::getUnitRatio`
- `MapsDistanceParser::getValidUnit` (same pattern, not in the issue's stack trace but would warn under different code paths)
- `CoordinateValue::getFormattedCoord`
- `DisplayMapRenderer::__construct`
- `AreaDescription::__construct`

The deprecation warnings emitted by `mediawiki/parser-hooks` (`ParserHooks\FunctionRunner`, `ParserHooks\Internal\Runner`, `ParserHooks\HookRunner`) originate from that library and need to be fixed in https://github.com/JeroenDeDauw/ParserHooks.

## Test plan
- [x] PHPUnit suite (247 tests) passes locally on PHP 8.3
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)