### PR TITLE
Allow ParserHooks 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 	"require": {
 		"php": ">=7.4",
 		"composer/installers": "^2.0.0|^1.0.1",
-		"mediawiki/parser-hooks": "~1.5",
+		"mediawiki/parser-hooks": "~1.5|~3.0",
 		"param-processor/param-processor": "^1.10",
 		"data-values/geo": "~4.0|~3.0",
 		"jeroen/file-fetcher": "~6.0|~5.0",


### PR DESCRIPTION
## Summary

[ParserHooks 3.0.0](https://github.com/JeroenDeDauw/ParserHooks/releases/tag/3.0.0) reverts to a pure PHP library distribution: no `extension.json`, no `i18n/`, no `wfLoadExtension` call. The classes Maps consumes -- `HookDefinition`, `HookHandler`, `HookRegistrant` -- are stable since ParserHooks 1.0 and unchanged between 1.6.x and 3.0.x, so the upgrade is API-safe.

This widens the constraint to allow ParserHooks 3.x alongside the existing 1.5+ range. Composer resolves the intersection of all installed extensions' constraints, so:

* Sites running Maps + an extension still pinning ParserHooks `~1.x` continue to get ParserHooks 1.6.x; nothing breaks.
* Sites running Maps alone (or alongside extensions also opting into 3.x) get ParserHooks 3.0.x.

No other Maps code change is needed.

## Migration note

When ParserHooks 3.0.x is selected, sites previously calling `wfLoadExtension( 'ParserHooks' )` should remove that line from `LocalSettings.php`; ParserHooks 3.x is a pure Composer library and no longer registers as a MediaWiki extension. Maps itself doesn't call `wfLoadExtension( 'ParserHooks' )` anywhere, so no Maps-side change is needed.

## Test plan

- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)