### PR TITLE
Fix compatibility with latest SMW master

### DIFF
--- a/src/SemanticMW/AreaDescription.php
+++ b/src/SemanticMW/AreaDescription.php
@@ -10,6 +10,7 @@ use Maps\GeoFunctions;
 use Maps\Presentation\MapsDistanceParser;
 use SMW\DataValueFactory;
 use SMW\DIProperty;
+use SMW\Query\Language\Description;
 use SMW\Query\Language\ThingDescription;
 use SMW\Query\Language\ValueDescription;
 use SMWDataItem;
@@ -43,7 +44,7 @@ class AreaDescription extends ValueDescription {
 	/**
 	 * @see Description::prune
 	 */
-	public function prune( &$maxsize, &$maxDepth, &$log ) {
+	public function prune( &$maxsize, &$maxDepth, &$log ): Description {
 		if ( ( $maxsize < $this->getSize() ) || ( $maxDepth < $this->getDepth() ) ) {
 			$log[] = $this->getQueryString();
 
@@ -59,7 +60,7 @@ class AreaDescription extends ValueDescription {
 		return $this;
 	}
 
-	public function getQueryString( $asValue = false ) {
+	public function getQueryString( $asValue = false ): string {
 		$centerString = DataValueFactory::getInstance()->newDataValueByItem(
 			$this->center,
 			$this->getProperty()

--- a/src/SemanticMW/CoordinateDescription.php
+++ b/src/SemanticMW/CoordinateDescription.php
@@ -16,7 +16,7 @@ use Wikimedia\Rdbms\IDatabase;
  */
 class CoordinateDescription extends ValueDescription {
 
-	public function getQueryString( $asValue = false ) {
+	public function getQueryString( $asValue = false ): string {
 		$queryString = DataValueFactory::getInstance()->newDataValueByItem(
 			$this->getDataItem(),
 			$this->getProperty()

--- a/src/SemanticMW/CoordinateValue.php
+++ b/src/SemanticMW/CoordinateValue.php
@@ -43,7 +43,7 @@ class CoordinateValue extends SMWDataValue {
 			throw new InvalidArgumentException( '$value needs to be a string' );
 		}
 
-		[ $distance, $comparator ] = $this->parseUserValue( $value );
+		[ $distance, $comparator ] = $this->parseAndReturnUserValue( $value );
 		$distance = $this->parserDistance( $distance );
 
 		$this->setUserValue( $value );
@@ -69,7 +69,11 @@ class CoordinateValue extends SMWDataValue {
 	/**
 	 * @see SMWDataValue::parseUserValue
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
+		$this->parseAndReturnUserValue( $value );
+	}
+
+	private function parseAndReturnUserValue( $value ): array {
 		if ( !is_string( $value ) ) {
 			throw new InvalidArgumentException( '$value needs to be a string' );
 		}
@@ -245,16 +249,14 @@ class CoordinateValue extends SMWDataValue {
 	 * $2: The location in directional DMS notation.
 	 * $3: The latitude in non-directional float notation.
 	 * $4 The longitude in non-directional float notation.
-	 *
-	 * @return array
 	 */
-	protected function getServiceLinkParams() {
+	protected function getServiceLinkParams(): array {
 		$coordinateSet = $this->m_dataitem->getCoordinateSet();
 		return [
 			$this->getFormattedCoord( $this->m_dataitem, 'float' ), // TODO
 			$this->getFormattedCoord( $this->m_dataitem, 'dms' ), // TODO
 			$coordinateSet['lat'],
-			$coordinateSet['lon']
+			$coordinateSet['lon'],
 		];
 	}
 

--- a/src/SemanticMW/KmlPrinter.php
+++ b/src/SemanticMW/KmlPrinter.php
@@ -86,10 +86,8 @@ class KmlPrinter extends FileExportPrinter {
 	 * @see SMWResultPrinter::getParamDefinitions
 	 *
 	 * @param ParamDefinition[] $definitions
-	 *
-	 * @return array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		global $egMapsDefaultLabel, $egMapsDefaultTitle;
 
 		$definitions['text'] = [
@@ -134,7 +132,7 @@ class KmlPrinter extends FileExportPrinter {
 	 *
 	 * @return string|boolean
 	 */
-	public function getFileName( QueryResult $queryResult ) {
+	public function getFileName( QueryResult $queryResult ): false|string {
 		if ( $this->params['filename'] !== '' ) {
 			$filename = $this->params['filename'];
 
@@ -160,7 +158,7 @@ class KmlPrinter extends FileExportPrinter {
 	 * @param array $params
 	 * @param $outputMode
 	 */
-	protected function handleParameters( array $params, $outputMode ) {
+	protected function handleParameters( array $params, $outputMode ): void {
 		$this->params = $params;
 	}
 }


### PR DESCRIPTION
I had to add a new `parseAndReturnUserValue` method to `CoordinateValue` because `parseUserValue` must have a return type of `void` now, but the return value of the method is used within `CoordinateValue`. If you have a better solution (I'm not familiar with this code at all, neither in Maps nor in SMW), please let me know.

Closes #895