### PR TITLE
Escape Leaflet layer control labels and enforce the available-layers whitelist

### DIFF
--- a/resources/leaflet/jquery.leaflet.js
+++ b/resources/leaflet/jquery.leaflet.js
@@ -291,7 +291,7 @@
 			let overlays = {};
 
 			$.each(options.overlays, function(index, overlayName) {
-				overlays[overlayName] = new L.tileLayer.provider(overlayName).addTo(_this.map);
+				overlays[mw.html.escape(overlayName)] = new L.tileLayer.provider(overlayName).addTo(_this.map);
 			});
 
 			return overlays;
@@ -306,7 +306,7 @@
 			if (layers.size > 1 || options.overlays.length > 0) {
 				let baseLayers = {};
 				layers.forEach(function(layerObject, layerName) {
-					baseLayers[layerName] = layerObject;
+					baseLayers[mw.html.escape(layerName)] = layerObject;
 				});
 				L.control.layers(baseLayers, overlays).addTo(this.map);
 			}

--- a/src/LeafletService.php
+++ b/src/LeafletService.php
@@ -241,7 +241,34 @@ class LeafletService implements MappingService {
 
 		$params['imageLayers'] = $this->getJsImageLayers( $params['image layers'] );
 
+		$params['overlays'] = $this->filterToAvailable(
+			$params['overlays'],
+			$GLOBALS['egMapsLeafletAvailableOverlayLayers']
+		);
+		$params['layers'] = $this->filterToAvailable(
+			$params['layers'],
+			$GLOBALS['egMapsLeafletAvailableLayers']
+		);
+
 		return new MapData( $params );
+	}
+
+	/**
+	 * Removes values that are not enabled in the available-layers whitelist. ParamProcessor only
+	 * adds a non-fatal warning for such values rather than dropping them, so without this an editor
+	 * can inject arbitrary strings that end up as Leaflet layer-control labels.
+	 *
+	 * @param string[] $values
+	 * @param array<string, bool> $available
+	 * @return string[]
+	 */
+	private function filterToAvailable( array $values, array $available ): array {
+		return array_values(
+			array_filter(
+				$values,
+				static fn ( string $value ): bool => ( $available[$value] ?? false ) === true
+			)
+		);
 	}
 
 	private function getJsImageLayers( array $imageLayers ) {

--- a/tests/Unit/LeafletServiceTest.php
+++ b/tests/Unit/LeafletServiceTest.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace Maps\Tests\Unit;
 
 use Maps\LeafletService;
+use Maps\Map\MapData;
 use Maps\Tests\TestDoubles\ImageValueObject;
 use Maps\Tests\TestDoubles\InMemoryImageRepository;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +15,27 @@ use ReflectionMethod;
  * @covers \Maps\LeafletService
  */
 class LeafletServiceTest extends TestCase {
+
+	private array $originalGlobals = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->originalGlobals = [
+			'egMapsLeafletAvailableLayers' => $GLOBALS['egMapsLeafletAvailableLayers'] ?? null,
+			'egMapsLeafletAvailableOverlayLayers' => $GLOBALS['egMapsLeafletAvailableOverlayLayers'] ?? null,
+		];
+
+		$GLOBALS['egMapsLeafletAvailableLayers'] = [ 'OpenStreetMap' => true, 'OpenTopoMap' => true ];
+		$GLOBALS['egMapsLeafletAvailableOverlayLayers'] = [ 'OpenSeaMap' => true, 'OpenRailwayMap' => true ];
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['egMapsLeafletAvailableLayers'] = $this->originalGlobals['egMapsLeafletAvailableLayers'];
+		$GLOBALS['egMapsLeafletAvailableOverlayLayers'] = $this->originalGlobals['egMapsLeafletAvailableOverlayLayers'];
+
+		parent::tearDown();
+	}
 
 	public function testZeroWidthImageLayerIsSkipped() {
 		$imageRepo = new InMemoryImageRepository();
@@ -43,6 +65,42 @@ class LeafletServiceTest extends TestCase {
 		$result = $this->getJsImageLayers( $imageRepo, [ 'missing.png' ] );
 
 		$this->assertSame( [], $result );
+	}
+
+	public function testNonWhitelistedOverlaysAreRemoved() {
+		$mapData = $this->newLeafletMapData( [
+			'overlays' => [ 'OpenSeaMap', '<img src=x onerror="alert(1)">', 'OpenRailwayMap' ]
+		] );
+
+		$this->assertSame(
+			[ 'OpenSeaMap', 'OpenRailwayMap' ],
+			$mapData->getParameters()['overlays']
+		);
+	}
+
+	public function testNonWhitelistedLayersAreRemoved() {
+		$mapData = $this->newLeafletMapData( [
+			'layers' => [ 'OpenStreetMap', '<img src=x onerror="alert(1)">', 'OpenTopoMap' ]
+		] );
+
+		$this->assertSame(
+			[ 'OpenStreetMap', 'OpenTopoMap' ],
+			$mapData->getParameters()['layers']
+		);
+	}
+
+	private function newLeafletMapData( array $overrides ): MapData {
+		$params = array_merge(
+			[
+				'geojson' => '',
+				'image layers' => [],
+				'layers' => [],
+				'overlays' => [],
+			],
+			$overrides
+		);
+
+		return ( new LeafletService( new InMemoryImageRepository() ) )->newMapDataFromParameters( $params );
 	}
 
 	private function getJsImageLayers( InMemoryImageRepository $imageRepo, array $imageLayers ): array {

--- a/tests/js/leaflet/JQueryLeafletTest.js
+++ b/tests/js/leaflet/JQueryLeafletTest.js
@@ -50,6 +50,36 @@
 		return jqueryMap;
 	}
 
+	// Helper: runs addLayersAndOverlays and returns the baseLayers/overlays objects
+	// handed to L.control.layers. Stubs L.control.layers so the names are never
+	// rendered (avoiding payload execution), and L.tileLayer.provider so arbitrary
+	// names don't hit the provider catalog.
+	function captureLayerControl( $div, options ) {
+		var jqueryMap = createTestMap( $div, options );
+
+		var stubLayer = { addTo: function () { return this; } };
+		var originalProvider = L.tileLayer.provider;
+		var originalControlLayers = L.control.layers;
+		var captured = {};
+
+		L.tileLayer.provider = function () { return stubLayer; };
+		L.control.layers = function ( baseLayers, overlays ) {
+			captured.baseLayers = baseLayers;
+			captured.overlays = overlays;
+			return stubLayer;
+		};
+
+		try {
+			jqueryMap.addLayersAndOverlays();
+		} finally {
+			L.control.layers = originalControlLayers;
+			L.tileLayer.provider = originalProvider;
+			jqueryMap.map.remove();
+		}
+
+		return captured;
+	}
+
 	QUnit.test( 'leafletmaps creates a jquery object with map methods', function ( assert ) {
 		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
 		var options = makeDefaultOptions();
@@ -146,6 +176,43 @@
 		assert.strictEqual( Object.keys( capturedOverlays ).length, 1, 'Overlays object has 1 entry' );
 
 		jqueryMap.map.remove();
+	} );
+
+	QUnit.test( 'addOverlays HTML-escapes overlay names used as layer-control labels', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var options = makeDefaultOptions( {
+			overlays: [ '<img src=x onerror="alert(1)">' ]
+		} );
+
+		var captured = captureLayerControl( $div, options );
+
+		assert.deepEqual(
+			Object.keys( captured.overlays ),
+			[ '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;' ],
+			'Overlay name is HTML-escaped before being used as a layer-control label'
+		);
+	} );
+
+	QUnit.test( 'addLayersAndOverlays HTML-escapes base layer names used as layer-control labels', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var options = makeDefaultOptions( {
+			layers: [ 'OpenStreetMap', '<img src=x onerror="alert(1)">' ]
+		} );
+
+		var captured = captureLayerControl( $div, options );
+
+		assert.true(
+			Object.prototype.hasOwnProperty.call( captured.baseLayers, '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;' ),
+			'Malicious base layer name is HTML-escaped'
+		);
+		assert.false(
+			Object.prototype.hasOwnProperty.call( captured.baseLayers, '<img src=x onerror="alert(1)">' ),
+			'Raw (unescaped) base layer name is not used as a key'
+		);
+		assert.true(
+			Object.prototype.hasOwnProperty.call( captured.baseLayers, 'OpenStreetMap' ),
+			'Legitimate base layer name is left unchanged'
+		);
 	} );
 
 	QUnit.test( 'centerAndZoomMap skips fitContent when both centre and zoom are set', function ( assert ) {


### PR DESCRIPTION
_Written by Claude Code, Opus 4.8. Result of iterative work with @JeroenDeDauw. Context: the Maps extension codebase (Leaflet service and layer control)._

The Leaflet layer control rendered base layer, overlay, and image layer names without escaping, and the `layers`/`overlays` parameters were not restricted to the configured available layers (ParamProcessor only emitted a non-fatal warning for values outside the whitelist).

This escapes layer and overlay names where they are used as Leaflet layer control labels (`addOverlays` and `addLayersAndOverlays`), and filters the `layers` and `overlays` parameters to the `egMapsLeafletAvailableLayers` / `egMapsLeafletAvailableOverlayLayers` whitelists in `LeafletService` so non-enabled values are dropped rather than passed through to the client.

**Behavior note:** this now enforces the available-layers whitelist that was previously only warned about. Wikis using custom layers must ensure they are listed in `egMapsLeafletAvailableLayers` / `egMapsLeafletAvailableOverlayLayers`.

Adds unit tests for the whitelist filtering and QUnit tests asserting the layer control labels are escaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
