### PR TITLE
Sanitize HTML in Cargo result popups

### DIFF
--- a/resources/GoogleMaps/jquery.googlemap.js
+++ b/resources/GoogleMaps/jquery.googlemap.js
@@ -90,10 +90,6 @@
 				labelClass: 'markerwithlabel'
 			};
 
-			if ( markerOptions.text !== '' ) {
-				markerOptions.text = $('<div>').text(markerOptions.text).text();
-			}
-
 			if (!markerData.hasOwnProperty('icon') || markerData.icon !== '') {
 				markerOptions.icon = markerData.icon;
 			}

--- a/src/Map/StructuredPopup.php
+++ b/src/Map/StructuredPopup.php
@@ -4,15 +4,13 @@ declare( strict_types = 1 );
 
 namespace Maps\Map;
 
-use DOMDocument;
-use DOMElement;
+use Maps\Presentation\HtmlSanitizer;
 
 class StructuredPopup {
 
-	private const SAFE_URL_SCHEMES = [ 'http', 'https', 'ftp', 'ftps', 'mailto', 'tel' ];
-
 	private string $titleHtml;
 	private array $propertyValues;
+	private HtmlSanitizer $sanitizer;
 
 	/**
 	 * @param string[] $propertyValues
@@ -20,10 +18,11 @@ class StructuredPopup {
 	public function __construct( string $titleHtml, array $propertyValues ) {
 		$this->titleHtml = $titleHtml;
 		$this->propertyValues = $propertyValues;
+		$this->sanitizer = new HtmlSanitizer();
 	}
 
 	public function getHtml(): string {
-		$title = $this->sanitize( $this->titleHtml );
+		$title = $this->sanitizer->sanitize( $this->titleHtml );
 		$valueList = $this->getPropertyValueList();
 		$separator = $title === '' || $valueList === '' ? '' : '<br>';
 
@@ -34,7 +33,7 @@ class StructuredPopup {
 		$lines = [];
 
 		foreach ( $this->propertyValues as $name => $value ) {
-			$lines[] = $this->bold( $this->sanitize( (string)$name ) ) . ': ' . $this->sanitize( $value );
+			$lines[] = $this->bold( $this->sanitizer->sanitize( (string)$name ) ) . ': ' . $this->sanitizer->sanitize( $value );
 		}
 
 		return implode( '<br>', $lines );
@@ -42,75 +41,6 @@ class StructuredPopup {
 
 	private function bold( string $html ): string {
 		return '<strong>' . $html . '</strong>';
-	}
-
-	/**
-	 * Keeps only <a> and <img> tags and strips event-handler attributes and unsafe URL schemes
-	 * from them. Relative and http(s) URLs are preserved so links to wiki pages and images that
-	 * the popup is meant to show keep working.
-	 */
-	private function sanitize( string $html ): string {
-		$html = strip_tags( $html, '<a><img>' );
-
-		if ( strpos( $html, '<' ) === false ) {
-			return $html;
-		}
-
-		return $this->stripDangerousAttributes( $html );
-	}
-
-	private function stripDangerousAttributes( string $html ): string {
-		$document = new DOMDocument();
-
-		$previousErrorHandling = libxml_use_internal_errors( true );
-		$loaded = $document->loadHTML(
-			'<?xml encoding="UTF-8"?><div>' . $html . '</div>',
-			LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
-		);
-		libxml_clear_errors();
-		libxml_use_internal_errors( $previousErrorHandling );
-
-		if ( !$loaded || $document->documentElement === null ) {
-			return strip_tags( $html );
-		}
-
-		foreach ( $document->getElementsByTagName( '*' ) as $element ) {
-			$this->stripDangerousAttributesFromElement( $element );
-		}
-
-		return $this->innerHtml( $document->documentElement );
-	}
-
-	private function stripDangerousAttributesFromElement( DOMElement $element ): void {
-		foreach ( iterator_to_array( $element->attributes ) as $attribute ) {
-			$name = strtolower( $attribute->name );
-
-			if ( strpos( $name, 'on' ) === 0 ) {
-				$element->removeAttribute( $attribute->name );
-			} elseif ( ( $name === 'href' || $name === 'src' ) && $this->hasUnsafeScheme( $attribute->value ) ) {
-				$element->removeAttribute( $attribute->name );
-			}
-		}
-	}
-
-	private function hasUnsafeScheme( string $url ): bool {
-		$normalized = strtolower( (string)preg_replace( '/[\x00-\x20]+/', '', $url ) );
-
-		if ( preg_match( '/^[a-z][a-z0-9+.\-]*:/', $normalized ) !== 1 ) {
-			return false;
-		}
-
-		return !in_array( strstr( $normalized, ':', true ), self::SAFE_URL_SCHEMES, true );
-	}
-
-	private function innerHtml( DOMElement $element ): string {
-		$html = '';
-
-		foreach ( $element->childNodes as $child ) {
-			$html .= $element->ownerDocument->saveHTML( $child );
-		}
-
-		return $html;
 	}
 
 }

--- a/src/Map/StructuredPopup.php
+++ b/src/Map/StructuredPopup.php
@@ -4,13 +4,17 @@ declare( strict_types = 1 );
 
 namespace Maps\Map;
 
+use DOMDocument;
+use DOMElement;
+
 class StructuredPopup {
+
+	private const SAFE_URL_SCHEMES = [ 'http', 'https', 'ftp', 'ftps', 'mailto', 'tel' ];
 
 	private string $titleHtml;
 	private array $propertyValues;
 
 	/**
-	 * @param string $titleHtml
 	 * @param string[] $propertyValues
 	 */
 	public function __construct( string $titleHtml, array $propertyValues ) {
@@ -19,28 +23,94 @@ class StructuredPopup {
 	}
 
 	public function getHtml(): string {
+		$title = $this->sanitize( $this->titleHtml );
 		$valueList = $this->getPropertyValueList();
-		$separator = $this->titleHtml === '' || $valueList === '' ? '' : '<br>';
+		$separator = $title === '' || $valueList === '' ? '' : '<br>';
 
-		return '<h3 style="padding-top: 0">' . $this->titleHtml . '</h3>' . $separator . $valueList;
+		return '<h3 style="padding-top: 0">' . $title . '</h3>' . $separator . $valueList;
 	}
 
 	private function getPropertyValueList(): string {
 		$lines = [];
 
 		foreach ( $this->propertyValues as $name => $value ) {
-			$lines[] = $this->bold( $this->stripTags( $name ) ) . ': ' . $this->stripTags( $value );
+			$lines[] = $this->bold( $this->sanitize( (string)$name ) ) . ': ' . $this->sanitize( $value );
 		}
 
 		return implode( '<br>', $lines );
 	}
 
-	private function stripTags( string $html ): string {
-		return strip_tags( $html, '<a><img>' );
-	}
-
 	private function bold( string $html ): string {
 		return '<strong>' . $html . '</strong>';
+	}
+
+	/**
+	 * Keeps only <a> and <img> tags and strips event-handler attributes and unsafe URL schemes
+	 * from them. Relative and http(s) URLs are preserved so links to wiki pages and images that
+	 * the popup is meant to show keep working.
+	 */
+	private function sanitize( string $html ): string {
+		$html = strip_tags( $html, '<a><img>' );
+
+		if ( strpos( $html, '<' ) === false ) {
+			return $html;
+		}
+
+		return $this->stripDangerousAttributes( $html );
+	}
+
+	private function stripDangerousAttributes( string $html ): string {
+		$document = new DOMDocument();
+
+		$previousErrorHandling = libxml_use_internal_errors( true );
+		$loaded = $document->loadHTML(
+			'<?xml encoding="UTF-8"?><div>' . $html . '</div>',
+			LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+		);
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previousErrorHandling );
+
+		if ( !$loaded || $document->documentElement === null ) {
+			return strip_tags( $html );
+		}
+
+		foreach ( $document->getElementsByTagName( '*' ) as $element ) {
+			$this->stripDangerousAttributesFromElement( $element );
+		}
+
+		return $this->innerHtml( $document->documentElement );
+	}
+
+	private function stripDangerousAttributesFromElement( DOMElement $element ): void {
+		foreach ( iterator_to_array( $element->attributes ) as $attribute ) {
+			$name = strtolower( $attribute->name );
+
+			if ( strpos( $name, 'on' ) === 0 ) {
+				$element->removeAttribute( $attribute->name );
+			} elseif ( ( $name === 'href' || $name === 'src' ) && $this->hasUnsafeScheme( $attribute->value ) ) {
+				$element->removeAttribute( $attribute->name );
+			}
+		}
+	}
+
+	private function hasUnsafeScheme( string $url ): bool {
+		$normalized = strtolower( (string)preg_replace( '/[\x00-\x20]+/', '', $url ) );
+
+		if ( preg_match( '/^[a-z][a-z0-9+.\-]*:/', $normalized ) !== 1 ) {
+			return false;
+		}
+
+		return !in_array( strstr( $normalized, ':', true ), self::SAFE_URL_SCHEMES, true );
+	}
+
+	private function innerHtml( DOMElement $element ): string {
+		$html = '';
+
+		foreach ( $element->childNodes as $child ) {
+			$html .= $element->ownerDocument->saveHTML( $child );
+		}
+
+		return $html;
 	}
 
 }

--- a/src/Presentation/HtmlSanitizer.php
+++ b/src/Presentation/HtmlSanitizer.php
@@ -1,0 +1,83 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Presentation;
+
+use DOMDocument;
+use DOMElement;
+
+/**
+ * Restricts HTML to a safe subset: only <a> and <img> tags are kept, with their event-handler
+ * attributes and unsafe URL schemes removed. Relative and http(s) URLs are preserved so that
+ * links to wiki pages and images keep working.
+ */
+class HtmlSanitizer {
+
+	private const SAFE_URL_SCHEMES = [ 'http', 'https', 'ftp', 'ftps', 'mailto', 'tel' ];
+
+	public function sanitize( string $html ): string {
+		$html = strip_tags( $html, '<a><img>' );
+
+		if ( strpos( $html, '<' ) === false ) {
+			return $html;
+		}
+
+		return $this->stripDangerousAttributes( $html );
+	}
+
+	private function stripDangerousAttributes( string $html ): string {
+		$document = new DOMDocument();
+
+		$previousErrorHandling = libxml_use_internal_errors( true );
+		$loaded = $document->loadHTML(
+			'<?xml encoding="UTF-8"?><div>' . $html . '</div>',
+			LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+		);
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previousErrorHandling );
+
+		if ( !$loaded || $document->documentElement === null ) {
+			return strip_tags( $html );
+		}
+
+		foreach ( $document->getElementsByTagName( '*' ) as $element ) {
+			$this->stripDangerousAttributesFromElement( $element );
+		}
+
+		return $this->innerHtml( $document->documentElement );
+	}
+
+	private function stripDangerousAttributesFromElement( DOMElement $element ): void {
+		foreach ( iterator_to_array( $element->attributes ) as $attribute ) {
+			$name = strtolower( $attribute->name );
+
+			if ( strpos( $name, 'on' ) === 0 ) {
+				$element->removeAttribute( $attribute->name );
+			} elseif ( ( $name === 'href' || $name === 'src' ) && $this->hasUnsafeScheme( $attribute->value ) ) {
+				$element->removeAttribute( $attribute->name );
+			}
+		}
+	}
+
+	private function hasUnsafeScheme( string $url ): bool {
+		$normalized = strtolower( (string)preg_replace( '/[\x00-\x20]+/', '', $url ) );
+
+		if ( preg_match( '/^[a-z][a-z0-9+.\-]*:/', $normalized ) !== 1 ) {
+			return false;
+		}
+
+		return !in_array( strstr( $normalized, ':', true ), self::SAFE_URL_SCHEMES, true );
+	}
+
+	private function innerHtml( DOMElement $element ): string {
+		$html = '';
+
+		foreach ( $element->childNodes as $child ) {
+			$html .= $element->ownerDocument->saveHTML( $child );
+		}
+
+		return $html;
+	}
+
+}

--- a/tests/Unit/Map/StructuredPopupTest.php
+++ b/tests/Unit/Map/StructuredPopupTest.php
@@ -58,4 +58,82 @@ class StructuredPopupTest extends TestCase {
 		);
 	}
 
+	public function testEventHandlerAttributeIsRemovedFromImage() {
+		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<img src="photo.jpg" onerror="alert(1)">' ] );
+
+		$this->assertStringNotContainsString( 'onerror', $html );
+		$this->assertStringContainsString( 'src="photo.jpg"', $html );
+	}
+
+	public function testJavascriptUrlIsRemovedFromLink() {
+		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="javascript:alert(1)">click</a>' ] );
+
+		$this->assertStringNotContainsString( 'javascript:', $html );
+		$this->assertStringContainsString( 'click', $html );
+	}
+
+	public function testObfuscatedJavascriptUrlIsRemovedFromLink() {
+		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="Java&#9;Script:alert(1)">click</a>' ] );
+
+		$this->assertStringNotContainsString( 'alert(1)', $html );
+	}
+
+	public function testDataUrlIsRemovedFromLink() {
+		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="data:text/html;base64,PHN2Zz4=">click</a>' ] );
+
+		$this->assertStringNotContainsString( 'data:', $html );
+	}
+
+	public function testEventHandlerInTitleIsRemoved() {
+		$html = $this->getHtml( '<img src="logo.png" onerror="alert(1)">', [] );
+
+		$this->assertStringNotContainsString( 'onerror', $html );
+		$this->assertStringContainsString( 'src="logo.png"', $html );
+	}
+
+	public function testRelativeLinkUrlIsPreserved() {
+		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="/wiki/Berlin">Berlin</a>' ] );
+
+		$this->assertStringContainsString( 'href="/wiki/Berlin"', $html );
+	}
+
+	public function testRelativeImageUrlIsPreserved() {
+		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<img src="/images/Berlin.jpg">' ] );
+
+		$this->assertStringContainsString( 'src="/images/Berlin.jpg"', $html );
+	}
+
+	public function testEventHandlerIsRemovedWhenAttributeValueContainsAngleBracket() {
+		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<img src="ok.jpg" alt="a>b" onerror="alert(1)">' ] );
+
+		$this->assertStringNotContainsString( 'onerror', $html );
+		$this->assertStringContainsString( 'src="ok.jpg"', $html );
+	}
+
+	public function testEntityEncodedColonInJavascriptUrlIsRemoved() {
+		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="javascript&#58;alert(1)">click</a>' ] );
+
+		$this->assertStringNotContainsString( 'javascript', $html );
+	}
+
+	public function testUppercaseJavascriptUrlIsRemoved() {
+		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="JAVASCRIPT:alert(1)">click</a>' ] );
+
+		$this->assertStringNotContainsString( 'alert(1)', $html );
+	}
+
+	public function testVbscriptUrlIsRemoved() {
+		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="vbscript:msgbox(1)">click</a>' ] );
+
+		$this->assertStringNotContainsString( 'vbscript', $html );
+	}
+
+	public function testEachElementIsSanitizedWhenValueHasMultiple() {
+		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="/wiki/A">A</a><img src="/b.jpg" onerror="alert(1)">' ] );
+
+		$this->assertStringNotContainsString( 'onerror', $html );
+		$this->assertStringContainsString( 'href="/wiki/A"', $html );
+		$this->assertStringContainsString( 'src="/b.jpg"', $html );
+	}
+
 }

--- a/tests/Unit/Map/StructuredPopupTest.php
+++ b/tests/Unit/Map/StructuredPopupTest.php
@@ -12,15 +12,15 @@ use PHPUnit\Framework\TestCase;
  */
 class StructuredPopupTest extends TestCase {
 
+	private function getHtml( string $titleHtml, array $propertyValues ): string {
+		return ( new StructuredPopup( $titleHtml, $propertyValues ) )->getHtml();
+	}
+
 	public function testWithoutPropertyValues() {
 		$this->assertSame(
 			'<h3 style="padding-top: 0">MyTitle</h3>',
 			$this->getHtml( 'MyTitle', [] )
 		);
-	}
-
-	private function getHtml( string $titleHtml, array $propertyValues ) {
-		return ( new StructuredPopup( $titleHtml, $propertyValues ) )->getHtml();
 	}
 
 	public function testTitleAndListAreSeparated() {
@@ -37,103 +37,25 @@ class StructuredPopupTest extends TestCase {
 		);
 	}
 
-	public function testLinksAreAllowed() {
-		$this->assertStringContainsString(
-			'<strong><a href="#">P1</a></strong>: <a href="#">P1</a>',
-			$this->getHtml( 'MyTitle', [ '<a href="#">P1</a>' => '<a href="#">P1</a>' ] )
+	public function testPropertyValuesAreSanitized() {
+		$this->assertStringNotContainsString(
+			'onerror',
+			$this->getHtml( 'MyTitle', [ 'P1' => '<img src="x.jpg" onerror="alert(1)">' ] )
 		);
 	}
 
-	public function testImagesAreAllowed() {
-		$this->assertStringContainsString(
-			'<img src="#">',
-			$this->getHtml( 'MyTitle', [ 'P1' => '<img src="#">' ] )
+	public function testPropertyNamesAreSanitized() {
+		$this->assertStringNotContainsString(
+			'onerror',
+			$this->getHtml( 'MyTitle', [ '<img src="x.jpg" onerror="alert(1)">' => 'V1' ] )
 		);
 	}
 
-	public function testRandomTagsAreFiltered() {
-		$this->assertStringContainsString(
-			'<strong>P1</strong>: abcde',
-			$this->getHtml( 'MyTitle', [ 'P1<script>' => '<ul><li>abc</li></ul>de' ] )
+	public function testTitleIsSanitized() {
+		$this->assertStringNotContainsString(
+			'onerror',
+			$this->getHtml( '<img src="x.jpg" onerror="alert(1)">', [] )
 		);
-	}
-
-	public function testEventHandlerAttributeIsRemovedFromImage() {
-		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<img src="photo.jpg" onerror="alert(1)">' ] );
-
-		$this->assertStringNotContainsString( 'onerror', $html );
-		$this->assertStringContainsString( 'src="photo.jpg"', $html );
-	}
-
-	public function testJavascriptUrlIsRemovedFromLink() {
-		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="javascript:alert(1)">click</a>' ] );
-
-		$this->assertStringNotContainsString( 'javascript:', $html );
-		$this->assertStringContainsString( 'click', $html );
-	}
-
-	public function testObfuscatedJavascriptUrlIsRemovedFromLink() {
-		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="Java&#9;Script:alert(1)">click</a>' ] );
-
-		$this->assertStringNotContainsString( 'alert(1)', $html );
-	}
-
-	public function testDataUrlIsRemovedFromLink() {
-		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="data:text/html;base64,PHN2Zz4=">click</a>' ] );
-
-		$this->assertStringNotContainsString( 'data:', $html );
-	}
-
-	public function testEventHandlerInTitleIsRemoved() {
-		$html = $this->getHtml( '<img src="logo.png" onerror="alert(1)">', [] );
-
-		$this->assertStringNotContainsString( 'onerror', $html );
-		$this->assertStringContainsString( 'src="logo.png"', $html );
-	}
-
-	public function testRelativeLinkUrlIsPreserved() {
-		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="/wiki/Berlin">Berlin</a>' ] );
-
-		$this->assertStringContainsString( 'href="/wiki/Berlin"', $html );
-	}
-
-	public function testRelativeImageUrlIsPreserved() {
-		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<img src="/images/Berlin.jpg">' ] );
-
-		$this->assertStringContainsString( 'src="/images/Berlin.jpg"', $html );
-	}
-
-	public function testEventHandlerIsRemovedWhenAttributeValueContainsAngleBracket() {
-		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<img src="ok.jpg" alt="a>b" onerror="alert(1)">' ] );
-
-		$this->assertStringNotContainsString( 'onerror', $html );
-		$this->assertStringContainsString( 'src="ok.jpg"', $html );
-	}
-
-	public function testEntityEncodedColonInJavascriptUrlIsRemoved() {
-		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="javascript&#58;alert(1)">click</a>' ] );
-
-		$this->assertStringNotContainsString( 'javascript', $html );
-	}
-
-	public function testUppercaseJavascriptUrlIsRemoved() {
-		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="JAVASCRIPT:alert(1)">click</a>' ] );
-
-		$this->assertStringNotContainsString( 'alert(1)', $html );
-	}
-
-	public function testVbscriptUrlIsRemoved() {
-		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="vbscript:msgbox(1)">click</a>' ] );
-
-		$this->assertStringNotContainsString( 'vbscript', $html );
-	}
-
-	public function testEachElementIsSanitizedWhenValueHasMultiple() {
-		$html = $this->getHtml( 'MyTitle', [ 'P1' => '<a href="/wiki/A">A</a><img src="/b.jpg" onerror="alert(1)">' ] );
-
-		$this->assertStringNotContainsString( 'onerror', $html );
-		$this->assertStringContainsString( 'href="/wiki/A"', $html );
-		$this->assertStringContainsString( 'src="/b.jpg"', $html );
 	}
 
 }

--- a/tests/Unit/Presentation/HtmlSanitizerTest.php
+++ b/tests/Unit/Presentation/HtmlSanitizerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\Unit\Presentation;
+
+use Maps\Presentation\HtmlSanitizer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Maps\Presentation\HtmlSanitizer
+ */
+class HtmlSanitizerTest extends TestCase {
+
+	private function sanitize( string $html ): string {
+		return ( new HtmlSanitizer() )->sanitize( $html );
+	}
+
+	public function testPlainTextIsUnchanged() {
+		$this->assertSame( 'Just text', $this->sanitize( 'Just text' ) );
+	}
+
+	public function testLinksAreAllowed() {
+		$this->assertStringContainsString(
+			'<a href="#">P1</a>',
+			$this->sanitize( '<a href="#">P1</a>' )
+		);
+	}
+
+	public function testImagesAreAllowed() {
+		$this->assertStringContainsString(
+			'<img src="#">',
+			$this->sanitize( '<img src="#">' )
+		);
+	}
+
+	public function testRandomTagsAreFiltered() {
+		$this->assertSame( 'abcde', $this->sanitize( '<ul><li>abc</li></ul>de' ) );
+	}
+
+	public function testEventHandlerAttributeIsRemovedFromImage() {
+		$html = $this->sanitize( '<img src="photo.jpg" onerror="alert(1)">' );
+
+		$this->assertStringNotContainsString( 'onerror', $html );
+		$this->assertStringContainsString( 'src="photo.jpg"', $html );
+	}
+
+	public function testJavascriptUrlIsRemovedFromLink() {
+		$html = $this->sanitize( '<a href="javascript:alert(1)">click</a>' );
+
+		$this->assertStringNotContainsString( 'javascript:', $html );
+		$this->assertStringContainsString( 'click', $html );
+	}
+
+	public function testObfuscatedJavascriptUrlIsRemovedFromLink() {
+		$this->assertStringNotContainsString(
+			'alert(1)',
+			$this->sanitize( '<a href="Java&#9;Script:alert(1)">click</a>' )
+		);
+	}
+
+	public function testEntityEncodedColonInJavascriptUrlIsRemoved() {
+		$this->assertStringNotContainsString(
+			'javascript',
+			$this->sanitize( '<a href="javascript&#58;alert(1)">click</a>' )
+		);
+	}
+
+	public function testUppercaseJavascriptUrlIsRemoved() {
+		$this->assertStringNotContainsString(
+			'alert(1)',
+			$this->sanitize( '<a href="JAVASCRIPT:alert(1)">click</a>' )
+		);
+	}
+
+	public function testDataUrlIsRemovedFromLink() {
+		$this->assertStringNotContainsString(
+			'data:',
+			$this->sanitize( '<a href="data:text/html;base64,PHN2Zz4=">click</a>' )
+		);
+	}
+
+	public function testVbscriptUrlIsRemovedFromLink() {
+		$this->assertStringNotContainsString(
+			'vbscript',
+			$this->sanitize( '<a href="vbscript:msgbox(1)">click</a>' )
+		);
+	}
+
+	public function testEventHandlerIsRemovedWhenAttributeValueContainsAngleBracket() {
+		$html = $this->sanitize( '<img src="ok.jpg" alt="a>b" onerror="alert(1)">' );
+
+		$this->assertStringNotContainsString( 'onerror', $html );
+		$this->assertStringContainsString( 'src="ok.jpg"', $html );
+	}
+
+	public function testRelativeLinkUrlIsPreserved() {
+		$this->assertStringContainsString(
+			'href="/wiki/Berlin"',
+			$this->sanitize( '<a href="/wiki/Berlin">Berlin</a>' )
+		);
+	}
+
+	public function testRelativeImageUrlIsPreserved() {
+		$this->assertStringContainsString(
+			'src="/images/Berlin.jpg"',
+			$this->sanitize( '<img src="/images/Berlin.jpg">' )
+		);
+	}
+
+	public function testEachElementIsSanitizedWhenThereAreMultiple() {
+		$html = $this->sanitize( '<a href="/wiki/A">A</a><img src="/b.jpg" onerror="alert(1)">' );
+
+		$this->assertStringNotContainsString( 'onerror', $html );
+		$this->assertStringContainsString( 'href="/wiki/A"', $html );
+		$this->assertStringContainsString( 'src="/b.jpg"', $html );
+	}
+
+}


### PR DESCRIPTION
Hardens HTML handling for Cargo result map popups:

- `StructuredPopup` now restricts content to `<a>` and `<img>` tags, strips event-handler attributes (`on*`) and unsafe URL schemes (`javascript:`, `data:`, `vbscript:`), and preserves relative and `http(s)` URLs so page links and file thumbnails keep working. The popup title is sanitized too (it was previously emitted unfiltered).
- Removes a dead no-op (`$('<div>').text(x).text()`, an identity round-trip) in the Google Maps marker code.

Regression tests cover event handlers, encoded/obfuscated and uppercase schemes, multiple elements per value, and relative-URL preservation.

---
_Written by Claude Code, Opus 4.8. Result of extensive back-and-forth with @JeroenDeDauw and his review of the popup rendering paths and chosen sanitization approach. Context: the Maps codebase — the Cargo, Leaflet, and Google Maps popup output paths._
