### PR TITLE
Use namespaced Semantic MediaWiki classes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,20 @@ jobs:
         include:
           - mw: 'REL1_43'
             php: 8.3
+            smw: ''
             experimental: false
           - mw: 'REL1_44'
             php: 8.3
+            smw: ''
             experimental: false
           - mw: 'REL1_45'
             php: 8.3
+            smw: ''
+            experimental: false
+          # Exercises the Semantic MediaWiki integration, which self-skips when SMW is absent.
+          - mw: 'REL1_43'
+            php: 8.3
+            smw: '^7.0'
             experimental: false
 
     runs-on: ubuntu-latest
@@ -46,7 +54,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v22
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-smw${{ matrix.smw }}-v23
 
       - name: Cache Composer cache
         uses: actions/cache@v4
@@ -61,7 +69,7 @@ jobs:
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
-        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} Maps
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} Maps ${{ matrix.smw }}
 
       - uses: actions/checkout@v4
         with:
@@ -71,6 +79,10 @@ jobs:
         run: composer config --no-plugins allow-plugins.composer/installers true
 
       - run: composer update
+
+      - name: Set up Semantic MediaWiki
+        if: matrix.smw != ''
+        run: php maintenance/update.php --quick
 
       - name: Run PHPUnit
         run: php tests/phpunit/phpunit.php -c extensions/Maps

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -4,6 +4,7 @@ set -ex
 
 MW_BRANCH=$1
 EXTENSION_NAME=$2
+SMW_VERSION=$3
 
 wget "https://github.com/wikimedia/mediawiki/archive/refs/heads/$MW_BRANCH.tar.gz" -nv
 
@@ -28,11 +29,20 @@ echo '$wgShowExceptionDetails = true;' >> LocalSettings.php
 echo '$wgShowDBErrorBacktrace = true;' >> LocalSettings.php
 echo '$wgDevelopmentWarnings = true;' >> LocalSettings.php
 
+# Optionally load Semantic MediaWiki before the extension under test, so that the
+# extension's Semantic MediaWiki integration registers and the tests that exercise
+# it actually run instead of self-skipping.
+SMW_REQUIRE=""
+if [ -n "$SMW_VERSION" ]; then
+	echo 'wfLoadExtension( "SemanticMediaWiki" );' >> LocalSettings.php
+	SMW_REQUIRE="\"mediawiki/semantic-media-wiki\": \"$SMW_VERSION\""
+fi
+
 echo 'wfLoadExtension( "'$EXTENSION_NAME'" );' >> LocalSettings.php
 
 cat <<EOT >> composer.local.json
 {
-  	"require": {},
+  	"require": { $SMW_REQUIRE },
 	"extra": {
 		"merge-plugin": {
 			"merge-dev": true,

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,12 @@ different releases and which versions of PHP and MediaWiki they support, see the
 [platform compatibility tables](INSTALL.md#platform-compatibility-and-release-status).
 
 
+## Maps 12.1.6
+
+Released on June 5th, 2026.
+
+* Fixed a fatal error when rendering coordinate values with Semantic MediaWiki 7, where the long text and tooltip output referenced the removed `SMW_HEADER_TOOLTIP` constant
+
 ## Maps 12.1.5
 
 Released on June 4th, 2026.

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Maps",
-	"version": "12.1.5",
+	"version": "12.1.6",
 
 	"author": [
 		"[https://EntropyWins.wtf/mediawiki Jeroen De Dauw]",

--- a/src/GeoJsonPages/Semantic/SemanticGeoJsonStore.php
+++ b/src/GeoJsonPages/Semantic/SemanticGeoJsonStore.php
@@ -6,10 +6,10 @@ namespace Maps\GeoJsonPages\Semantic;
 
 use Maps\GeoJsonPages\GeoJsonStore;
 use MediaWiki\Title\Title;
-use SMW\DIProperty;
+use SMW\DataItems\Property;
 use SMW\EventDispatcher\EventDispatcher;
 use SMW\ParserData;
-use SMWDIContainer;
+use SMW\DataItems\Container;
 
 class SemanticGeoJsonStore implements GeoJsonStore {
 
@@ -28,8 +28,8 @@ class SemanticGeoJsonStore implements GeoJsonStore {
 	public function storeGeoJson( string $geoJson ) {
 		foreach ( $this->subObjectBuilder->getSubObjectsFromGeoJson( $geoJson ) as $subObject ) {
 			$this->parserData->getSemanticData()->addPropertyObjectValue(
-				new DIProperty( DIProperty::TYPE_SUBOBJECT ),
-				new SMWDIContainer( $subObject->toContainerSemanticData( $this->subjectPage->getTitleValue() ) )
+				new Property( Property::TYPE_SUBOBJECT ),
+				new Container( $subObject->toContainerSemanticData( $this->subjectPage->getTitleValue() ) )
 			);
 		}
 

--- a/src/GeoJsonPages/Semantic/SubObject.php
+++ b/src/GeoJsonPages/Semantic/SubObject.php
@@ -5,16 +5,17 @@ declare( strict_types = 1 );
 namespace Maps\GeoJsonPages\Semantic;
 
 use SMW\DataModel\ContainerSemanticData;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
 use TitleValue;
+use SMW\DataItems\DataItem;
 
 class SubObject {
 
 	private string $name;
 
 	/**
-	 * @var array<string, array<int, \SMWDataItem>>
+	 * @var array<string, array<int, DataItem>>
 	 */
 	private array $values = [];
 
@@ -22,7 +23,7 @@ class SubObject {
 		$this->name = $name;
 	}
 
-	public function addPropertyValuePair( string $propertyName, \SMWDataItem $dataItem ) {
+	public function addPropertyValuePair( string $propertyName, DataItem $dataItem ) {
 		$this->values[$propertyName][] = $dataItem;
 	}
 
@@ -32,7 +33,7 @@ class SubObject {
 		foreach ( $this->values as $propertyName => $dataItems ) {
 			foreach ( $dataItems as $dataItem ) {
 				$container->addPropertyObjectValue(
-					new DIProperty( $propertyName ),
+					new Property( $propertyName ),
 					$dataItem
 				);
 			}
@@ -43,7 +44,7 @@ class SubObject {
 
 	private function newContainerSemanticData( TitleValue $subjectPage ): ContainerSemanticData {
 		return new ContainerSemanticData(
-			new DIWikiPage(
+			new WikiPage(
 				$subjectPage->getDBkey(),
 				$subjectPage->getNamespace(),
 				$subjectPage->getInterwiki(),

--- a/src/GeoJsonPages/Semantic/SubObjectBuilder.php
+++ b/src/GeoJsonPages/Semantic/SubObjectBuilder.php
@@ -8,6 +8,8 @@ use GeoJson\Exception\UnserializationException;
 use GeoJson\Feature\FeatureCollection;
 use GeoJson\GeoJson;
 use GeoJson\Geometry\Point;
+use SMW\DataItems\GeoCoord;
+use SMW\DataItems\Blob;
 
 class SubObjectBuilder {
 
@@ -45,20 +47,20 @@ class SubObjectBuilder {
 
 		$subObject->addPropertyValuePair(
 			'HasCoordinates',
-			new \SMWDIGeoCoord( $point->getCoordinates()[1], $point->getCoordinates()[0] )
+			new GeoCoord( $point->getCoordinates()[1], $point->getCoordinates()[0] )
 		);
 
 		if ( array_key_exists( 'description', $properties ) && is_string( $properties['description'] ) ) {
 			$subObject->addPropertyValuePair(
 				'HasDescription',
-				new \SMWDIBlob( $properties['description'] )
+				new Blob( $properties['description'] )
 			);
 		}
 
 		if ( array_key_exists( 'title', $properties ) && is_string( $properties['title'] ) ) {
 			$subObject->addPropertyValuePair(
 				'HasTitle',
-				new \SMWDIBlob( $properties['title'] )
+				new Blob( $properties['title'] )
 			);
 		}
 

--- a/src/Map/SemanticFormat/MapPrinter.php
+++ b/src/Map/SemanticFormat/MapPrinter.php
@@ -20,7 +20,7 @@ use MediaWiki\Title\Title;
 use MediaWiki\Parser\Parser;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;
-use SMWOutputs;
+use SMW\MediaWiki\Outputs;
 
 /**
  * @licence GNU GPL v2+
@@ -140,13 +140,13 @@ class MapPrinter extends ResultPrinter {
 	}
 
 	private function outputResources( MapOutput $mapOutput ) {
-		SMWOutputs::requireHeadItem(
+		Outputs::requireHeadItem(
 			$this->randomString(),
 			$mapOutput->getHeadItems()
 		);
 
 		foreach ( $mapOutput->getResourceModules() as $resourceModule ) {
-			SMWOutputs::requireResource( $resourceModule );
+			Outputs::requireResource( $resourceModule );
 		}
 	}
 

--- a/src/SemanticMW/AreaDescription.php
+++ b/src/SemanticMW/AreaDescription.php
@@ -9,13 +9,13 @@ use InvalidArgumentException;
 use Maps\GeoFunctions;
 use Maps\Presentation\MapsDistanceParser;
 use SMW\DataValueFactory;
-use SMW\DIProperty;
+use SMW\DataItems\Property;
 use SMW\Query\Language\Description;
 use SMW\Query\Language\ThingDescription;
 use SMW\Query\Language\ValueDescription;
-use SMWDataItem;
-use SMWDIGeoCoord;
 use Wikimedia\Rdbms\IDatabase;
+use SMW\DataItems\GeoCoord;
+use SMW\DataItems\DataItem;
 
 /**
  * Description of a geographical area defined by a coordinates set and a distance to the bounds.
@@ -27,12 +27,12 @@ use Wikimedia\Rdbms\IDatabase;
  */
 class AreaDescription extends ValueDescription {
 
-	private SMWDIGeoCoord $center;
+	private GeoCoord $center;
 	private string $radius;
 
-	public function __construct( SMWDataItem $areaCenter, int $comparator, string $radius, ?DIProperty $property = null ) {
-		if ( !( $areaCenter instanceof SMWDIGeoCoord ) ) {
-			throw new InvalidArgumentException( '$areaCenter needs to be a SMWDIGeoCoord' );
+	public function __construct( DataItem $areaCenter, int $comparator, string $radius, ?Property $property = null ) {
+		if ( !( $areaCenter instanceof GeoCoord ) ) {
+			throw new InvalidArgumentException( '$areaCenter needs to be a GeoCoord' );
 		}
 
 		parent::__construct( $areaCenter, $property, $comparator );
@@ -83,7 +83,7 @@ class AreaDescription extends ValueDescription {
 	 * @return string|false
 	 */
 	public function getSQLCondition( $tableName, array $fieldNames, IDatabase $db ) {
-		if ( $this->center->getDIType() != SMWDataItem::TYPE_GEO ) {
+		if ( $this->center->getDIType() != DataItem::TYPE_GEO ) {
 			throw new \LogicException( 'Constructor should have prevented this' );
 		}
 

--- a/src/SemanticMW/CoordinateDescription.php
+++ b/src/SemanticMW/CoordinateDescription.php
@@ -6,8 +6,8 @@ namespace Maps\SemanticMW;
 
 use SMW\DataValueFactory;
 use SMW\Query\Language\ValueDescription;
-use SMWDIGeoCoord;
 use Wikimedia\Rdbms\IDatabase;
+use SMW\DataItems\GeoCoord;
 
 /**
  * Description of one data value of type Geographical Coordinates.
@@ -41,7 +41,7 @@ class CoordinateDescription extends ValueDescription {
 
 		// Only execute the query when the description's type is geographical coordinates,
 		// the description is valid, and the near comparator is used.
-		if ( $dataItem instanceof SMWDIGeoCoord ) {
+		if ( $dataItem instanceof GeoCoord ) {
 			switch ( $this->getComparator() ) {
 				case SMW_CMP_EQ:
 					$comparator = '=';

--- a/src/SemanticMW/CoordinateValue.php
+++ b/src/SemanticMW/CoordinateValue.php
@@ -12,25 +12,25 @@ use Maps\Presentation\MapsDistanceParser;
 use SMW\Query\Language\Description;
 use SMW\Query\Language\ThingDescription;
 use SMW\Query\QueryComparator;
-use SMWDataItem;
-use SMWDataValue;
-use SMWDIGeoCoord;
-use SMWOutputs;
 use ValueParsers\ParseException;
+use SMW\DataValues\DataValue;
+use SMW\DataItems\GeoCoord;
+use SMW\DataItems\DataItem;
+use SMW\MediaWiki\Outputs;
 
 /**
- * @property SMWDIGeoCoord m_dataitem
+ * @property GeoCoord m_dataitem
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Markus Krötzsch
  */
-class CoordinateValue extends SMWDataValue {
+class CoordinateValue extends DataValue {
 
 	private $wikiValue;
 
 	/**
-	 * Overwrite SMWDataValue::getQueryDescription() to be able to process
+	 * Overwrite DataValue::getQueryDescription() to be able to process
 	 * comparators between all values.
 	 *
 	 * @param string $value
@@ -67,7 +67,7 @@ class CoordinateValue extends SMWDataValue {
 	}
 
 	/**
-	 * @see SMWDataValue::parseUserValue
+	 * @see DataValue::parseUserValue
 	 */
 	protected function parseUserValue( $value ): void {
 		$this->parseAndReturnUserValue( $value );
@@ -110,14 +110,14 @@ class CoordinateValue extends SMWDataValue {
 
 		try {
 			$value = $parser->parse( $coordinates );
-			$this->m_dataitem = new SMWDIGeoCoord( $value->getLatitude(), $value->getLongitude() );
+			$this->m_dataitem = new GeoCoord( $value->getLatitude(), $value->getLongitude() );
 		}
 		catch ( ParseException $parseException ) {
 			$this->addError( wfMessage( 'maps_unrecognized_coords', $coordinates, 1 )->text() );
 
 			// Make sure this is always set
 			// TODO: Why is this needed?!
-			$this->m_dataitem = new SMWDIGeoCoord( [ 'lat' => 0, 'lon' => 0 ] );
+			$this->m_dataitem = new GeoCoord( [ 'lat' => 0, 'lon' => 0 ] );
 		}
 	}
 
@@ -135,7 +135,7 @@ class CoordinateValue extends SMWDataValue {
 	}
 
 	/**
-	 * @see SMWDataValue::getShortHTMLText
+	 * @see DataValue::getShortHTMLText
 	 *
 	 * @since 0.6
 	 */
@@ -144,7 +144,7 @@ class CoordinateValue extends SMWDataValue {
 	}
 
 	/**
-	 * @see SMWDataValue::getShortWikiText
+	 * @see DataValue::getShortWikiText
 	 */
 	public function getShortWikiText( $linker = null ) {
 		if ( $this->isValid() ) {
@@ -159,12 +159,12 @@ class CoordinateValue extends SMWDataValue {
 	}
 
 	/**
-	 * @param SMWDIGeoCoord $dataItem
+	 * @param GeoCoord $dataItem
 	 * @param string|null $format
 	 *
 	 * @return string|null
 	 */
-	private function getFormattedCoord( SMWDIGeoCoord $dataItem, ?string $format = null ) {
+	private function getFormattedCoord( GeoCoord $dataItem, ?string $format = null ) {
 		return MapsFactory::globalInstance()->getCoordinateFormatter()->format(
 			new LatLongValue(
 				$dataItem->getLatitude(),
@@ -176,21 +176,21 @@ class CoordinateValue extends SMWDataValue {
 	}
 
 	/**
-	 * @see SMWDataValue::getLongHTMLText
+	 * @see DataValue::getLongHTMLText
 	 */
 	public function getLongHTMLText( $linker = null ) {
 		return $this->getLongWikiText( $linker );
 	}
 
 	/**
-	 * @see SMWDataValue::getLongWikiText
+	 * @see DataValue::getLongWikiText
 	 *
 	 * @since 0.6
 	 */
 	public function getLongWikiText( $linked = null ) {
 		if ( $this->isValid() ) {
-			SMWOutputs::requireStyle( 'ext.smw.tooltip.styles' );
-			SMWOutputs::requireResource( 'ext.smw.tooltip' );
+			Outputs::requireStyle( 'ext.smw.tooltip.styles' );
+			Outputs::requireResource( 'ext.smw.tooltip' );
 
 			// TODO: fix lang keys so they include the space and coordinates.
 			$coordinateSet = $this->m_dataitem->getCoordinateSet();
@@ -215,21 +215,21 @@ class CoordinateValue extends SMWDataValue {
 	}
 
 	/**
-	 * @see SMWDataValue::getWikiValue
+	 * @see DataValue::getWikiValue
 	 */
 	public function getWikiValue() {
 		return $this->wikiValue;
 	}
 
 	/**
-	 * @see SMWDataValue::setDataItem
+	 * @see DataValue::setDataItem
 	 *
-	 * @param SMWDataItem $dataItem
+	 * @param DataItem $dataItem
 	 *
 	 * @return boolean
 	 */
-	protected function loadDataItem( SMWDataItem $dataItem ) {
-		if ( $dataItem instanceof SMWDIGeoCoord ) {
+	protected function loadDataItem( DataItem $dataItem ) {
+		if ( $dataItem instanceof GeoCoord ) {
 			$formattedValue = $this->getFormattedCoord( $dataItem );
 
 			if ( $formattedValue !== null ) {
@@ -262,7 +262,7 @@ class CoordinateValue extends SMWDataValue {
 	}
 
 	/**
-	 * @return SMWDIGeoCoord|\SMWDIError
+	 * @return GeoCoord|\SMW\DataItems\Error
 	 */
 	public function getDataItem() {
 		return parent::getDataItem();

--- a/src/SemanticMW/CoordinateValue.php
+++ b/src/SemanticMW/CoordinateValue.php
@@ -189,7 +189,8 @@ class CoordinateValue extends SMWDataValue {
 	 */
 	public function getLongWikiText( $linked = null ) {
 		if ( $this->isValid() ) {
-			SMWOutputs::requireHeadItem( SMW_HEADER_TOOLTIP );
+			SMWOutputs::requireStyle( 'ext.smw.tooltip.styles' );
+			SMWOutputs::requireResource( 'ext.smw.tooltip' );
 
 			// TODO: fix lang keys so they include the space and coordinates.
 			$coordinateSet = $this->m_dataitem->getCoordinateSet();

--- a/src/SemanticMW/KmlPrinter.php
+++ b/src/SemanticMW/KmlPrinter.php
@@ -83,7 +83,7 @@ class KmlPrinter extends FileExportPrinter {
 	}
 
 	/**
-	 * @see SMWResultPrinter::getParamDefinitions
+	 * @see \SMW\Query\ResultPrinters\ResultPrinter::getParamDefinitions
 	 *
 	 * @param ParamDefinition[] $definitions
 	 */
@@ -115,7 +115,7 @@ class KmlPrinter extends FileExportPrinter {
 	}
 
 	/**
-	 * @see SMWIExportPrinter::getMimeType
+	 * @see \SMW\Query\ExportPrinter::getMimeType
 	 *
 	 * @param QueryResult $queryResult
 	 *
@@ -126,7 +126,7 @@ class KmlPrinter extends FileExportPrinter {
 	}
 
 	/**
-	 * @see SMWIExportPrinter::getFileName
+	 * @see \SMW\Query\ExportPrinter::getFileName
 	 *
 	 * @param QueryResult $queryResult
 	 *

--- a/src/SemanticMW/QueryHandler.php
+++ b/src/SemanticMW/QueryHandler.php
@@ -16,9 +16,10 @@ use MediaWiki\MediaWikiServices;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryResult;
 use SMW\Query\Result\ResultArray;
-use SMWDataValue;
-use SMWDIGeoCoord;
-use SMWWikiPageValue;
+use SMW\DataValues\DataValue;
+use SMW\DataItems\GeoCoord;
+use SMW\DataValues\WikiPageValue;
+use SMW\DataValues\RecordValue;
 
 /**
  * @licence GNU GPL v2+
@@ -175,7 +176,7 @@ class QueryHandler {
 	 */
 	private function getTitleAndText( ResultArray $resultArray ): array {
 		while ( ( $dataValue = $resultArray->getNextDataValue() ) !== false ) {
-			if ( $dataValue instanceof SMWWikiPageValue ) {
+			if ( $dataValue instanceof WikiPageValue ) {
 				return [
 					$dataValue->getLongText( $this->outputMode, null ),
 					$this->getResultSubjectText( $dataValue )
@@ -209,9 +210,9 @@ class QueryHandler {
 
 			// Loop through all the parts of the field value.
 			while ( ( $dataValue = $resultArray->getNextDataValue() ) !== false ) {
-				if ( $dataValue instanceof \SMWRecordValue ) {
+				if ( $dataValue instanceof RecordValue ) {
 					foreach ( $dataValue->getDataItems() as $dataItem ) {
-						if ( $dataItem instanceof \SMWDIGeoCoord ) {
+						if ( $dataItem instanceof GeoCoord ) {
 							$locations[] = $this->locationFromDataItem( $dataItem );
 						}
 					}
@@ -239,7 +240,7 @@ class QueryHandler {
 		return [ $locations, $properties ];
 	}
 
-	private function locationFromDataItem( SMWDIGeoCoord $dataItem ): Location {
+	private function locationFromDataItem( GeoCoord $dataItem ): Location {
 		return Location::newFromLatLon(
 			$dataItem->getLatitude(),
 			$dataItem->getLongitude()
@@ -247,14 +248,14 @@ class QueryHandler {
 	}
 
 	/**
-	 * Handles a SMWWikiPageValue subject value.
+	 * Handles a WikiPageValue subject value.
 	 * Gets the plain text title and creates the HTML text with headers and the like.
 	 *
-	 * @param SMWWikiPageValue $object
+	 * @param WikiPageValue $object
 	 *
 	 * @return string
 	 */
-	private function getResultSubjectText( SMWWikiPageValue $object ): string {
+	private function getResultSubjectText( WikiPageValue $object ): string {
 		if ( !$this->showSubject ) {
 			return '';
 		}
@@ -291,10 +292,10 @@ class QueryHandler {
 	}
 
 	/**
-	 * Handles a single property (\SMW\Query\PrintRequest) to be displayed for a record (SMWDataValue).
+	 * Handles a single property (\SMW\Query\PrintRequest) to be displayed for a record (DataValue).
 	 * Returns the full property display string including header (e.g., "Property Name: value").
 	 */
-	private function handleResultProperty( SMWDataValue $object, PrintRequest $printRequest ): string {
+	private function handleResultProperty( DataValue $object, PrintRequest $printRequest ): string {
 		if ( $this->hasTemplate() ) {
 			return $this->handleResultPropertyValue( $object, $printRequest );
 		}
@@ -307,9 +308,9 @@ class QueryHandler {
 	 * Returns just the value portion of a property, without the header.
 	 * Used for appending additional values of multi-valued properties.
 	 */
-	private function handleResultPropertyValue( SMWDataValue $object, PrintRequest $printRequest ): string {
+	private function handleResultPropertyValue( DataValue $object, PrintRequest $printRequest ): string {
 		if ( $this->hasTemplate() ) {
-			if ( $object instanceof SMWWikiPageValue ) {
+			if ( $object instanceof WikiPageValue ) {
 				return $object->getDataItem()->getTitle()->getPrefixedText();
 			}
 
@@ -350,7 +351,7 @@ class QueryHandler {
 		return $this->linkStyle === 'all' ? smwfGetLinker() : null;
 	}
 
-	private function getPropertyValue( SMWDataValue $object ): string {
+	private function getPropertyValue( DataValue $object ): string {
 		if ( !$this->linkAbsolute ) {
 			return $object->getLongHTMLText(
 				$this->getValueLinker()
@@ -373,7 +374,7 @@ class QueryHandler {
 		return $object->getLongText( $this->outputMode, null );
 	}
 
-	private function hasPage( SMWDataValue $object ): bool {
+	private function hasPage( DataValue $object ): bool {
 		$hasPage = $object->getTypeID() == '_wpg';
 
 		if ( $hasPage ) {

--- a/src/SemanticMapsSetup.php
+++ b/src/SemanticMapsSetup.php
@@ -8,7 +8,7 @@ use Maps\Map\SemanticFormat\MapPrinter;
 use Maps\SemanticMW\CoordinateValue;
 use Maps\SemanticMW\KmlPrinter;
 use SMW\DataTypeRegistry;
-use SMWDataItem;
+use SMW\DataItems\DataItem;
 
 /**
  * @licence GNU GPL v2+
@@ -29,7 +29,7 @@ class SemanticMapsSetup {
 			DataTypeRegistry::getInstance()->registerDatatype(
 				'_geo',
 				CoordinateValue::class,
-				SMWDataItem::TYPE_GEO
+				DataItem::TYPE_GEO
 			);
 
 			return true;

--- a/tests/Unit/SemanticMW/CoordinateValueTest.php
+++ b/tests/Unit/SemanticMW/CoordinateValueTest.php
@@ -40,6 +40,16 @@ class CoordinateValueTest extends TestCase {
 		$this->assertSame( '23° 0\' 0.00" N, 42° 0\' 0.00" E', $geoValue->getShortWikiText() );
 	}
 
+	public function testGetLongTextRendersTooltipWithoutFatal() {
+		$geoValue = DataValueFactory::getInstance()->newDataValueByItem( new SMWDIGeoCoord( 23, 42 ) );
+
+		$longWikiText = $geoValue->getLongWikiText();
+
+		$this->assertStringContainsString( 'smwttinline', $longWikiText );
+		$this->assertStringContainsString( 'smwttcontent', $longWikiText );
+		$this->assertSame( $longWikiText, $geoValue->getLongHTMLText() );
+	}
+
 	/**
 	 * @dataProvider coordinateProvider
 	 */


### PR DESCRIPTION
First piece of the 13.0.0 cycle (Semantic MediaWiki 7 only).

## What

Replaces every deprecated Semantic MediaWiki class alias Maps used with its SMW 7 canonical namespaced class:

- Global aliases: `SMWDataValue`→`SMW\DataValues\DataValue`, `SMWDIGeoCoord`→`SMW\DataItems\GeoCoord`, `SMWDataItem`→`SMW\DataItems\DataItem`, `SMWOutputs`→`SMW\MediaWiki\Outputs`, `SMWDIContainer`→`SMW\DataItems\Container`, `SMWDIBlob`→`SMW\DataItems\Blob`, `SMWWikiPageValue`→`SMW\DataValues\WikiPageValue`, `SMWRecordValue`→`SMW\DataValues\RecordValue`.
- Namespaced aliases: `SMW\DIProperty`→`SMW\DataItems\Property`, `SMW\DIWikiPage`→`SMW\DataItems\WikiPage`.
- Inline FQN uses are converted to `use` imports; `@see` docblocks point at the canonical classes.

These aliases are `@deprecated` in Semantic MediaWiki 7 and slated for removal in a future major. Semantic Maps already requires Semantic MediaWiki 7 (the 12.1.x line uses SMW-7-only APIs such as `SMW\EventDispatcher\EventDispatcher` and `SMWOutputs::requireStyle()`), so this is internal cleanup with no behavior change.

## Verification

Against MediaWiki 1.43 + Semantic MediaWiki 7.0: full suite `OK (265 tests, 449 assertions)`; every renamed class resolves; no new PHPCS violations under Maps' ruleset.

## Notes

- Builds on #904 (the 12.1.6 fatal fix); its commits drop out of this diff once #904 merges.
- No version bump or release-note entry here — the repo has no convention for tagging in-development versions, so the 13.0.0 bump and the "requires Semantic MediaWiki 7 / dropped 6" release note belong with the eventual release that also carries the rest of the 13.0.0 breaking changes.