### PR TITLE
fix: resolve custom marker popup left-alignment

### DIFF
--- a/resources/leaflet/FeatureBuilder.js
+++ b/resources/leaflet/FeatureBuilder.js
@@ -24,7 +24,7 @@
 					iconUrl: properties.icon,
 					iconSize: [ img.width, img.height ],
 					iconAnchor: [ img.width / 2, img.height ],
-					popupAnchor: [ -img.width / 2, -img.height*2/3 ]
+					popupAnchor: [ 0, -img.height*2/3 ]
 				});
 
 				marker.setIcon(icon);


### PR DESCRIPTION
This PR resolves an issue where Leaflet marker popups are horizontally misaligned (shifted to the left) when loading custom marker icons. 

Fixes #914