### PR TITLE
Serialize imageoverlays in query result formats

### DIFF
--- a/src/Map/SemanticFormat/MapPrinter.php
+++ b/src/Map/SemanticFormat/MapPrinter.php
@@ -115,6 +115,11 @@ class MapPrinter extends ResultPrinter {
 		$params['circles'] = $this->elementsToJson( $params['circles'] );
 		$params['rectangles'] = $this->elementsToJson( $params['rectangles'] );
 
+		// Only the Google Maps service defines this parameter.
+		if ( array_key_exists( 'imageoverlays', $params ) ) {
+			$params['imageoverlays'] = $this->elementsToJson( $params['imageoverlays'] );
+		}
+
 		$params['ajaxquery'] = urlencode( $params['ajaxquery'] );
 
 		if ( $params['locations'] === [] ) {

--- a/tests/System/SemanticQueryTest.php
+++ b/tests/System/SemanticQueryTest.php
@@ -63,6 +63,21 @@ class SemanticQueryTest extends TestCase {
 		$this->assertStringContainsString( '"geojson":{"type":"FeatureCollection"', $content );
 	}
 
+	public function testGoogleMapsQueryContainsImageOverlayData() {
+		$this->createDataPages();
+
+		$content = htmlspecialchars_decode(
+			$this->getResultForQuery(
+				'{{#ask:[[Coordinates::+]]|?Coordinates|format=googlemaps3'
+				. '|imageoverlays=52.1,13.1:51.9,12.9:TestOverlay.png}}'
+			)
+		);
+
+		$this->assertStringContainsString( '"image":"TestOverlay.png"', $content );
+		$this->assertStringContainsString( '"ne":{"lon":13.1,"lat":52.1}', $content );
+		$this->assertStringContainsString( '"sw":{"lon":12.9,"lat":51.9}', $content );
+	}
+
 	private function getResultForQuery( string $query ): string {
 		$this->pageCreator->createPage(
 			'MapQuery',


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/Maps/issues/919

MapPrinter converted lines, polygons, circles and rectangles into JSON-ready arrays, but not imageoverlays. The parameter was still accepted and parsed into `ImageOverlay` objects, which have no public properties, so each one serialized to `{}` and the map data ended up containing `"imageoverlays":[{}]`. The Google Maps JS then dereferenced `properties.sw.lat` on that empty object and threw, so the map did not render at all.

imageoverlays therefore never worked in any query result format. That includes `#compound_query`, which passes its parameters straight through to MapPrinter and needs no changes of its own.

Only the Google Maps service defines the parameter, so the conversion is guarded by a key check, the same way `DisplayMapRenderer` guards it for `#display_map`.

The regression test was seen failing on master (emitting `"imageoverlays":[{}]`) before the fix was written. Mutation testing confirms both branches are covered: removing the new block fails only the new test, while dropping the key check fails the Leaflet and default-format tests with `Undefined array key`, so the guard is load-bearing rather than defensive padding.

### Out of scope

Three related things this deliberately does not touch:

* **Leaflet support for `imageoverlays` (#651).** The parameter remains Google Maps only. This PR just makes it behave in `#ask` the way it already behaves in `#display_map`.
* **The stray `"imageoverlays":null` on Leaflet maps.** `DisplayMapRenderer::handleShapeData()` takes `&$params['imageoverlays']` unconditionally, so on Leaflet, where the key does not exist, PHP's reference semantics create it, and every Leaflet map ships a meaningless `"imageoverlays":null`. Harmless today since the Leaflet JS never reads it, and unrelated to the crash fixed here. It would become a real bug the moment #651 lands.
* **The Cargo output path, which may have the same defect more broadly.** `CargoOutputBuilder` inherits the mapping service's parameter definitions but contains no `elementToJson` call at all, so `format=map` in Cargo looks like it would emit `[{}]` for *every* shape type, not just imageoverlays. Not verified and not reproduced, so no issue filed. Worth a look.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; one-line ask from @JeroenDeDauw to fix a bug it had diagnosed earlier in the session, no redirections; diff not yet human-reviewed; regression test seen failing then passing, 4 mutations all caught, full Maps PHPUnit suite green locally (264 tests), CI green including PHPStan, code style and QUnit.</sub>
