### PR TITLE
Add egMapsLeafletLayerDefinitions setting for custom Leaflet layers

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -252,6 +252,40 @@ return [
 		'NASAGIBS.ModisTerraChlorophyll' => true
 	],
 
+	// Custom named tile layers that can be used as base layers or overlays, in addition to the
+	// stock leaflet-providers layers listed above. The name of each definition becomes a valid
+	// value for the layers and overlays parameters. Only the definitions actually used by a map
+	// are sent to the browser.
+	//
+	// Each definition has a 'url' (required, an XYZ tile template or, for WMS, the service
+	// endpoint), an optional 'options' array passed straight to Leaflet, and an optional 'wms'
+	// flag. Definitions without a non-empty url string are ignored.
+	//
+	// Example:
+	// 'egMapsLeafletLayerDefinitions' => [
+	//     'Historic 1904' => [
+	//         'url' => 'https://tiles.example.org/historic1904/{z}/{x}/{y}.png',
+	//         'options' => [
+	//             'attribution' => 'Historic map tiles',
+	//             'minZoom' => 1,
+	//             'maxZoom' => 18,
+	//             'subdomains' => 'abc',
+	//             'bounds' => [ [ 49.5, 5.8 ], [ 53.6, 15.2 ] ],
+	//         ],
+	//     ],
+	//     'Weather WMS' => [
+	//         'wms' => true,
+	//         'url' => 'https://example.org/geoserver/wms',
+	//         'options' => [
+	//             'layers' => 'weather:precipitation',
+	//             'format' => 'image/png',
+	//             'transparent' => true,
+	//             'attribution' => 'Weather service',
+	//         ],
+	//     ],
+	// ],
+	'egMapsLeafletLayerDefinitions' => [],
+
 	'egMapsLeafletLayersApiKeys' => [
 		'MapBox' => '',
 		'MapQuestOpen' => '',

--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -261,6 +261,9 @@ return [
 	// endpoint), an optional 'options' array passed straight to Leaflet, and an optional 'wms'
 	// flag. Definitions without a non-empty url string are ignored.
 	//
+	// A definition whose name matches a stock layer (e.g. 'OpenStreetMap') overrides that stock
+	// layer. The 'options' are passed to Leaflet as-is; note that 'attribution' is rendered as HTML.
+	//
 	// Example:
 	// 'egMapsLeafletLayerDefinitions' => [
 	//     'Historic 1904' => [

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,12 @@ different releases and which versions of PHP and MediaWiki they support, see the
 [platform compatibility tables](INSTALL.md#platform-compatibility-and-release-status).
 
 
+## Maps 13.1.0
+
+Released on TBD.
+
+* Added the `$egMapsLeafletLayerDefinitions` setting to define custom named Leaflet tile and WMS layers, which can then be used as values of the `layers` and `overlays` parameters
+
 ## Maps 13.0.2
 
 Released on July 14th, 2026.

--- a/resources/leaflet/jquery.leaflet.js
+++ b/resources/leaflet/jquery.leaflet.js
@@ -272,7 +272,7 @@
 		// Returns the custom layer definition for the given name, or null when there is none.
 		// Definitions are supplied per map via options.layerDefinitions (see LeafletService).
 		this.getLayerDefinition = function(layerName) {
-			if (options.layerDefinitions && options.layerDefinitions.hasOwnProperty(layerName)) {
+			if (options.layerDefinitions && Object.prototype.hasOwnProperty.call(options.layerDefinitions, layerName)) {
 				return options.layerDefinitions[layerName];
 			}
 

--- a/resources/leaflet/jquery.leaflet.js
+++ b/resources/leaflet/jquery.leaflet.js
@@ -249,6 +249,11 @@
 		};
 
 		this.newBaseLayerFromName = function(layerName) {
+			let definition = this.getLayerDefinition(layerName);
+			if (definition !== null) {
+				return this.newLayerFromDefinition(definition);
+			}
+
 			if (layerName === 'MapQuestOpen') {
 				return new window.MQ.TileLayer();
 			}
@@ -262,6 +267,24 @@
 			}
 
 			return new L.tileLayer.provider(layerName, layerOptions);
+		};
+
+		// Returns the custom layer definition for the given name, or null when there is none.
+		// Definitions are supplied per map via options.layerDefinitions (see LeafletService).
+		this.getLayerDefinition = function(layerName) {
+			if (options.layerDefinitions && options.layerDefinitions.hasOwnProperty(layerName)) {
+				return options.layerDefinitions[layerName];
+			}
+
+			return null;
+		};
+
+		this.newLayerFromDefinition = function(definition) {
+			if (definition.wms) {
+				return L.tileLayer.wms(definition.url, definition.options);
+			}
+
+			return L.tileLayer(definition.url, definition.options);
 		};
 
 		this.getImageBaseLayers = function() {
@@ -291,7 +314,12 @@
 			let overlays = {};
 
 			$.each(options.overlays, function(index, overlayName) {
-				overlays[mw.html.escape(overlayName)] = new L.tileLayer.provider(overlayName).addTo(_this.map);
+				let definition = _this.getLayerDefinition(overlayName);
+				let overlay = definition !== null
+					? _this.newLayerFromDefinition(definition)
+					: new L.tileLayer.provider(overlayName);
+
+				overlays[mw.html.escape(overlayName)] = overlay.addTo(_this.map);
 			});
 
 			return overlays;

--- a/src/LeafletLayerDefinitions.php
+++ b/src/LeafletLayerDefinitions.php
@@ -1,0 +1,83 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps;
+
+/**
+ * Admin-defined custom Leaflet base and overlay layers, configured via
+ * $egMapsLeafletLayerDefinitions. Normalizes and validates the raw configuration and is the
+ * single source of truth for which custom layer names exist and what their definition is.
+ *
+ * @licence GNU GPL v2+
+ */
+class LeafletLayerDefinitions {
+
+	/**
+	 * @var array<string, array{url: string, options: array, wms: bool}>
+	 */
+	private array $definitions;
+
+	/**
+	 * @param array $rawDefinitions Layer name to raw definition, as configured via
+	 *        $egMapsLeafletLayerDefinitions. Invalid definitions are skipped.
+	 */
+	public function __construct( array $rawDefinitions ) {
+		$this->definitions = $this->normalizeAll( $rawDefinitions );
+	}
+
+	private function normalizeAll( array $rawDefinitions ): array {
+		$definitions = [];
+
+		foreach ( $rawDefinitions as $name => $rawDefinition ) {
+			$definition = $this->normalize( $rawDefinition );
+
+			if ( $definition !== null ) {
+				$definitions[$name] = $definition;
+			}
+		}
+
+		return $definitions;
+	}
+
+	/**
+	 * @return array{url: string, options: array, wms: bool}|null
+	 */
+	private function normalize( mixed $rawDefinition ): ?array {
+		if ( !is_array( $rawDefinition ) ) {
+			return null;
+		}
+
+		$url = $rawDefinition['url'] ?? null;
+
+		if ( !is_string( $url ) || $url === '' ) {
+			return null;
+		}
+
+		return [
+			'url' => $url,
+			'options' => is_array( $rawDefinition['options'] ?? null ) ? $rawDefinition['options'] : [],
+			'wms' => (bool)( $rawDefinition['wms'] ?? false ),
+		];
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getLayerNames(): array {
+		return array_keys( $this->definitions );
+	}
+
+	/**
+	 * @param string[] $names
+	 * @return array<string, array{url: string, options: array, wms: bool}> Normalized definitions
+	 *         for the requested names that are defined. Unknown names are omitted.
+	 */
+	public function getDefinitions( array $names ): array {
+		return array_intersect_key(
+			$this->definitions,
+			array_fill_keys( $names, true )
+		);
+	}
+
+}

--- a/src/LeafletService.php
+++ b/src/LeafletService.php
@@ -16,10 +16,12 @@ use ParamProcessor\ProcessingResult;
 class LeafletService implements MappingService {
 
 	private ImageRepository $imageFinder;
+	private LeafletLayerDefinitions $layerDefinitions;
 	private array $addedDependencies = [];
 
-	public function __construct( ImageRepository $imageFinder ) {
+	public function __construct( ImageRepository $imageFinder, LeafletLayerDefinitions $layerDefinitions ) {
 		$this->imageFinder = $imageFinder;
+		$this->layerDefinitions = $layerDefinitions;
 	}
 
 	public function getName(): string {
@@ -51,7 +53,7 @@ class LeafletService implements MappingService {
 			'aliases' => 'layer',
 			'type' => 'string',
 			'islist' => true,
-			'values' => array_keys( $GLOBALS['egMapsLeafletAvailableLayers'], true, true ),
+			'values' => $this->availableLayerNames( $GLOBALS['egMapsLeafletAvailableLayers'] ),
 			'default' => $GLOBALS['egMapsLeafletLayers'],
 			'message' => 'maps-leaflet-par-layers',
 		];
@@ -68,7 +70,7 @@ class LeafletService implements MappingService {
 			'aliases' => [ 'overlaylayers' ],
 			'type' => ParameterTypes::STRING,
 			'islist' => true,
-			'values' => array_keys( $GLOBALS['egMapsLeafletAvailableOverlayLayers'], true, true ),
+			'values' => $this->availableLayerNames( $GLOBALS['egMapsLeafletAvailableOverlayLayers'] ),
 			'default' => $GLOBALS['egMapsLeafletOverlayLayers'],
 			'message' => 'maps-leaflet-par-overlaylayers',
 		];
@@ -143,6 +145,24 @@ class LeafletService implements MappingService {
 		];
 
 		return $params;
+	}
+
+	/**
+	 * The enabled stock layer names plus the names of the custom layer definitions, which are
+	 * valid values for both the layers and overlays parameters.
+	 *
+	 * @param array<string, bool> $availableStockLayers
+	 * @return string[]
+	 */
+	private function availableLayerNames( array $availableStockLayers ): array {
+		return array_values(
+			array_unique(
+				array_merge(
+					array_keys( $availableStockLayers, true, true ),
+					$this->layerDefinitions->getLayerNames()
+				)
+			)
+		);
 	}
 
 	/**
@@ -243,12 +263,14 @@ class LeafletService implements MappingService {
 
 		$params['overlays'] = $this->filterToAvailable(
 			$params['overlays'],
-			$GLOBALS['egMapsLeafletAvailableOverlayLayers']
+			$this->availableWithDefinitions( $GLOBALS['egMapsLeafletAvailableOverlayLayers'] )
 		);
 		$params['layers'] = $this->filterToAvailable(
 			$params['layers'],
-			$GLOBALS['egMapsLeafletAvailableLayers']
+			$this->availableWithDefinitions( $GLOBALS['egMapsLeafletAvailableLayers'] )
 		);
+
+		$params = $this->addUsedLayerDefinitions( $params );
 
 		return new MapData( $params );
 	}
@@ -269,6 +291,33 @@ class LeafletService implements MappingService {
 				static fn ( string $value ): bool => ( $available[$value] ?? false ) === true
 			)
 		);
+	}
+
+	/**
+	 * @param array<string, bool> $available
+	 * @return array<string, bool>
+	 */
+	private function availableWithDefinitions( array $available ): array {
+		return array_merge(
+			$available,
+			array_fill_keys( $this->layerDefinitions->getLayerNames(), true )
+		);
+	}
+
+	/**
+	 * Serializes the custom layer definitions actually used by this map into the map data, so only
+	 * the relevant definitions are shipped to the client rather than the whole catalog.
+	 */
+	private function addUsedLayerDefinitions( array $params ): array {
+		$usedDefinitions = $this->layerDefinitions->getDefinitions(
+			array_merge( $params['layers'], $params['overlays'] )
+		);
+
+		if ( $usedDefinitions !== [] ) {
+			$params['layerDefinitions'] = $usedDefinitions;
+		}
+
+		return $params;
 	}
 
 	private function getJsImageLayers( array $imageLayers ) {

--- a/src/LeafletService.php
+++ b/src/LeafletService.php
@@ -298,10 +298,10 @@ class LeafletService implements MappingService {
 	 * @return array<string, bool>
 	 */
 	private function availableWithDefinitions( array $available ): array {
-		return array_merge(
-			$available,
-			array_fill_keys( $this->layerDefinitions->getLayerNames(), true )
-		);
+		// Union rather than array_merge: array_merge renumbers integer-like keys, which would drop
+		// a custom layer whose name is purely numeric (e.g. "1904"). Custom names go on the left so
+		// they take precedence over a same-named stock layer.
+		return array_fill_keys( $this->layerDefinitions->getLayerNames(), true ) + $available;
 	}
 
 	/**

--- a/src/MapsFactory.php
+++ b/src/MapsFactory.php
@@ -191,10 +191,15 @@ class MapsFactory {
 
 	private function getLeafletService(): LeafletService {
 		$this->leafletService ??= new LeafletService(
-			$this->getImageRepository()
+			$this->getImageRepository(),
+			$this->getLeafletLayerDefinitions()
 		);
 
 		return $this->leafletService;
+	}
+
+	public function getLeafletLayerDefinitions(): LeafletLayerDefinitions {
+		return new LeafletLayerDefinitions( $this->settings['egMapsLeafletLayerDefinitions'] ?? [] );
 	}
 
 	public function getDisplayMapFunction(): DisplayMapFunction {

--- a/tests/Integration/Parser/LeafletTest.php
+++ b/tests/Integration/Parser/LeafletTest.php
@@ -4,12 +4,35 @@ declare( strict_types = 1 );
 
 namespace Maps\Tests\Integration\Parser;
 
+use Maps\LeafletLayerDefinitions;
+use Maps\LeafletService;
 use Maps\Tests\MapsTestFactory;
 use Maps\Tests\TestDoubles\ImageValueObject;
+use Maps\Tests\TestDoubles\InMemoryImageRepository;
 use Maps\Tests\Util\TestFactory;
 use PHPUnit\Framework\TestCase;
 
 class LeafletTest extends TestCase {
+
+	private array $originalLayerDefinitions;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->originalLayerDefinitions = $GLOBALS['egMapsLeafletLayerDefinitions'] ?? [];
+		$this->setLayerDefinitions( [] );
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['egMapsLeafletLayerDefinitions'] = $this->originalLayerDefinitions;
+
+		parent::tearDown();
+	}
+
+	private function setLayerDefinitions( array $definitions ): void {
+		$GLOBALS['egMapsLeafletLayerDefinitions'] = $definitions;
+		MapsTestFactory::newTestInstance();
+	}
 
 	private function parse( string $textToParse ): string {
 		return TestFactory::newInstance()->parse( $textToParse );
@@ -51,6 +74,52 @@ class LeafletTest extends TestCase {
 		$this->assertStringContainsData( '"url":"/tmp/example/image.png"', $html );
 		$this->assertStringContainsData( '"width":100', $html );
 		$this->assertStringContainsData( '"height":50', $html );
+	}
+
+	public function testCustomLayerNameIsAValidLayerValue() {
+		$service = new LeafletService(
+			new InMemoryImageRepository(),
+			new LeafletLayerDefinitions( [ 'Historic' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ] ] )
+		);
+
+		$values = $service->getParameterInfo()['layers']['values'];
+
+		$this->assertContains( 'Historic', $values );
+		$this->assertContains( 'OpenStreetMap', $values );
+	}
+
+	public function testCustomLayerNameIsAValidOverlayValue() {
+		$service = new LeafletService(
+			new InMemoryImageRepository(),
+			new LeafletLayerDefinitions( [ 'Historic' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ] ] )
+		);
+
+		$values = $service->getParameterInfo()['overlays']['values'];
+
+		$this->assertContains( 'Historic', $values );
+		$this->assertContains( 'OpenSeaMap', $values );
+	}
+
+	public function testUsedCustomLayerDefinitionIsSerializedIntoMapData() {
+		$this->setLayerDefinitions( [
+			'Historic' => [
+				'url' => 'https://tiles.example/historic/{z}/{x}/{y}.png',
+				'options' => [ 'attribution' => 'Historic tiles' ],
+			],
+		] );
+
+		$html = $this->parse( '{{#leaflet:layers=Historic}}' );
+
+		$this->assertStringContainsData( '"layerDefinitions":', $html );
+		$this->assertStringContainsData( '"url":"https://tiles.example/historic/{z}/{x}/{y}.png"', $html );
+		$this->assertStringContainsData( '"attribution":"Historic tiles"', $html );
+		$this->assertStringContainsData( '"wms":false', $html );
+	}
+
+	public function testMapWithoutCustomLayersHasNoLayerDefinitions() {
+		$html = $this->parse( '{{#leaflet:}}' );
+
+		$this->assertStringNotContainsString( 'layerDefinitions', $html );
 	}
 
 }

--- a/tests/Unit/LeafletLayerDefinitionsTest.php
+++ b/tests/Unit/LeafletLayerDefinitionsTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\Unit;
+
+use Maps\LeafletLayerDefinitions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Maps\LeafletLayerDefinitions
+ */
+class LeafletLayerDefinitionsTest extends TestCase {
+
+	public function testTileDefinitionIsNormalized() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Historic' => [
+				'url' => 'https://tiles.example/{z}/{x}/{y}.png',
+				'options' => [ 'attribution' => 'Example', 'maxZoom' => 18 ],
+			],
+		] );
+
+		$this->assertSame(
+			[
+				'Historic' => [
+					'url' => 'https://tiles.example/{z}/{x}/{y}.png',
+					'options' => [ 'attribution' => 'Example', 'maxZoom' => 18 ],
+					'wms' => false,
+				],
+			],
+			$definitions->getDefinitions( [ 'Historic' ] )
+		);
+	}
+
+	public function testWmsDefinitionKeepsWmsFlag() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Weather' => [
+				'wms' => true,
+				'url' => 'https://example/wms',
+				'options' => [ 'layers' => 'hist1904', 'format' => 'image/png', 'transparent' => true ],
+			],
+		] );
+
+		$this->assertSame(
+			[
+				'Weather' => [
+					'url' => 'https://example/wms',
+					'options' => [ 'layers' => 'hist1904', 'format' => 'image/png', 'transparent' => true ],
+					'wms' => true,
+				],
+			],
+			$definitions->getDefinitions( [ 'Weather' ] )
+		);
+	}
+
+	public function testOptionsDefaultToEmptyArray() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Bare' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ],
+		] );
+
+		$this->assertSame(
+			[ 'url' => 'https://tiles.example/{z}/{x}/{y}.png', 'options' => [], 'wms' => false ],
+			$definitions->getDefinitions( [ 'Bare' ] )['Bare']
+		);
+	}
+
+	public function testDefinitionWithoutUrlIsSkipped() {
+		$definitions = new LeafletLayerDefinitions( [
+			'NoUrl' => [ 'options' => [ 'attribution' => 'x' ] ],
+		] );
+
+		$this->assertSame( [], $definitions->getLayerNames() );
+		$this->assertSame( [], $definitions->getDefinitions( [ 'NoUrl' ] ) );
+	}
+
+	public function testDefinitionWithEmptyUrlIsSkipped() {
+		$definitions = new LeafletLayerDefinitions( [
+			'EmptyUrl' => [ 'url' => '' ],
+		] );
+
+		$this->assertSame( [], $definitions->getLayerNames() );
+	}
+
+	public function testDefinitionWithNonStringUrlIsSkipped() {
+		$definitions = new LeafletLayerDefinitions( [
+			'NumberUrl' => [ 'url' => 123 ],
+		] );
+
+		$this->assertSame( [], $definitions->getLayerNames() );
+	}
+
+	public function testNonArrayDefinitionIsSkipped() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Weird' => 'not-an-array',
+		] );
+
+		$this->assertSame( [], $definitions->getLayerNames() );
+	}
+
+	public function testUnknownKeysAreIgnored() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Extra' => [
+				'url' => 'https://tiles.example/{z}/{x}/{y}.png',
+				'unknown' => 'ignored',
+			],
+		] );
+
+		$this->assertSame(
+			[ 'url', 'options', 'wms' ],
+			array_keys( $definitions->getDefinitions( [ 'Extra' ] )['Extra'] )
+		);
+	}
+
+	public function testGetLayerNamesListsOnlyValidDefinitions() {
+		$definitions = new LeafletLayerDefinitions( [
+			'First' => [ 'url' => 'https://tiles.example/1/{z}/{x}/{y}.png' ],
+			'Invalid' => [ 'options' => [] ],
+			'Last' => [ 'url' => 'https://tiles.example/2/{z}/{x}/{y}.png' ],
+		] );
+
+		$this->assertSame( [ 'First', 'Last' ], $definitions->getLayerNames() );
+	}
+
+	public function testGetDefinitionsSelectsRequestedName() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Before' => [ 'url' => 'https://tiles.example/b/{z}/{x}/{y}.png' ],
+			'Wanted' => [ 'url' => 'https://tiles.example/w/{z}/{x}/{y}.png' ],
+			'After' => [ 'url' => 'https://tiles.example/a/{z}/{x}/{y}.png' ],
+		] );
+
+		$this->assertSame(
+			[ 'Wanted' ],
+			array_keys( $definitions->getDefinitions( [ 'Wanted' ] ) )
+		);
+	}
+
+	public function testGetDefinitionsOmitsUnknownNames() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Known' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ],
+		] );
+
+		$this->assertSame( [], $definitions->getDefinitions( [ 'Unknown' ] ) );
+	}
+
+}

--- a/tests/Unit/LeafletServiceTest.php
+++ b/tests/Unit/LeafletServiceTest.php
@@ -185,6 +185,26 @@ class LeafletServiceTest extends TestCase {
 		$this->assertArrayNotHasKey( 'layerDefinitions', $mapData->getParameters() );
 	}
 
+	public function testDefinitionShadowingStockLayerIsSerialized() {
+		$mapData = $this->newLeafletMapData(
+			[ 'layers' => [ 'OpenStreetMap' ] ],
+			new LeafletLayerDefinitions( [
+				'OpenSeaMap' => [ 'url' => 'https://tiles.example/before/{z}/{x}/{y}.png' ],
+				'OpenStreetMap' => [ 'url' => 'https://tiles.example/shadow/{z}/{x}/{y}.png' ],
+				'OpenTopoMap' => [ 'url' => 'https://tiles.example/after/{z}/{x}/{y}.png' ],
+			] )
+		);
+
+		$this->assertSame(
+			[ 'OpenStreetMap' ],
+			array_keys( $mapData->getParameters()['layerDefinitions'] )
+		);
+		$this->assertSame(
+			'https://tiles.example/shadow/{z}/{x}/{y}.png',
+			$mapData->getParameters()['layerDefinitions']['OpenStreetMap']['url']
+		);
+	}
+
 	private function newLeafletMapData( array $overrides, ?LeafletLayerDefinitions $layerDefinitions = null ): MapData {
 		$params = array_merge(
 			[

--- a/tests/Unit/LeafletServiceTest.php
+++ b/tests/Unit/LeafletServiceTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace Maps\Tests\Unit;
 
+use Maps\LeafletLayerDefinitions;
 use Maps\LeafletService;
 use Maps\Map\MapData;
 use Maps\Tests\TestDoubles\ImageValueObject;
@@ -89,7 +90,102 @@ class LeafletServiceTest extends TestCase {
 		);
 	}
 
-	private function newLeafletMapData( array $overrides ): MapData {
+	public function testCustomLayerDefinitionSurvivesFiltering() {
+		$mapData = $this->newLeafletMapData(
+			[ 'layers' => [ 'OpenStreetMap', 'Historic', '<img src=x onerror="alert(1)">' ] ],
+			new LeafletLayerDefinitions( [
+				'Historic' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ],
+			] )
+		);
+
+		$this->assertSame(
+			[ 'OpenStreetMap', 'Historic' ],
+			$mapData->getParameters()['layers']
+		);
+	}
+
+	public function testCustomOverlayDefinitionSurvivesFiltering() {
+		$mapData = $this->newLeafletMapData(
+			[ 'overlays' => [ 'OpenSeaMap', 'Historic', '<img src=x onerror="alert(1)">' ] ],
+			new LeafletLayerDefinitions( [
+				'Historic' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ],
+			] )
+		);
+
+		$this->assertSame(
+			[ 'OpenSeaMap', 'Historic' ],
+			$mapData->getParameters()['overlays']
+		);
+	}
+
+	public function testUsedLayerDefinitionIsSerializedIntoMapData() {
+		$mapData = $this->newLeafletMapData(
+			[ 'layers' => [ 'OpenStreetMap', 'Historic' ] ],
+			new LeafletLayerDefinitions( [
+				'Historic' => [
+					'url' => 'https://tiles.example/{z}/{x}/{y}.png',
+					'options' => [ 'attribution' => 'Example' ],
+				],
+			] )
+		);
+
+		$this->assertSame(
+			[
+				'Historic' => [
+					'url' => 'https://tiles.example/{z}/{x}/{y}.png',
+					'options' => [ 'attribution' => 'Example' ],
+					'wms' => false,
+				],
+			],
+			$mapData->getParameters()['layerDefinitions']
+		);
+	}
+
+	public function testDefinitionUsedAsOverlayIsSerializedIntoMapData() {
+		$mapData = $this->newLeafletMapData(
+			[ 'overlays' => [ 'OpenSeaMap', 'Historic' ] ],
+			new LeafletLayerDefinitions( [
+				'Historic' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ],
+			] )
+		);
+
+		$this->assertArrayHasKey( 'Historic', $mapData->getParameters()['layerDefinitions'] );
+	}
+
+	public function testOnlyUsedLayerDefinitionsAreSerialized() {
+		$mapData = $this->newLeafletMapData(
+			[ 'layers' => [ 'Used' ] ],
+			new LeafletLayerDefinitions( [
+				'Unused' => [ 'url' => 'https://tiles.example/unused/{z}/{x}/{y}.png' ],
+				'Used' => [ 'url' => 'https://tiles.example/used/{z}/{x}/{y}.png' ],
+				'AlsoUnused' => [ 'url' => 'https://tiles.example/also/{z}/{x}/{y}.png' ],
+			] )
+		);
+
+		$this->assertSame(
+			[ 'Used' ],
+			array_keys( $mapData->getParameters()['layerDefinitions'] )
+		);
+	}
+
+	public function testLayerDefinitionsKeyIsAbsentWhenNoneAreConfigured() {
+		$mapData = $this->newLeafletMapData( [ 'layers' => [ 'OpenStreetMap' ] ] );
+
+		$this->assertArrayNotHasKey( 'layerDefinitions', $mapData->getParameters() );
+	}
+
+	public function testLayerDefinitionsKeyIsAbsentWhenConfiguredDefinitionsAreUnused() {
+		$mapData = $this->newLeafletMapData(
+			[ 'layers' => [ 'OpenStreetMap' ] ],
+			new LeafletLayerDefinitions( [
+				'Historic' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ],
+			] )
+		);
+
+		$this->assertArrayNotHasKey( 'layerDefinitions', $mapData->getParameters() );
+	}
+
+	private function newLeafletMapData( array $overrides, ?LeafletLayerDefinitions $layerDefinitions = null ): MapData {
 		$params = array_merge(
 			[
 				'geojson' => '',
@@ -100,11 +196,22 @@ class LeafletServiceTest extends TestCase {
 			$overrides
 		);
 
-		return ( new LeafletService( new InMemoryImageRepository() ) )->newMapDataFromParameters( $params );
+		return $this->newService( new InMemoryImageRepository(), $layerDefinitions )
+			->newMapDataFromParameters( $params );
+	}
+
+	private function newService(
+		InMemoryImageRepository $imageRepo,
+		?LeafletLayerDefinitions $layerDefinitions = null
+	): LeafletService {
+		return new LeafletService(
+			$imageRepo,
+			$layerDefinitions ?? new LeafletLayerDefinitions( [] )
+		);
 	}
 
 	private function getJsImageLayers( InMemoryImageRepository $imageRepo, array $imageLayers ): array {
-		$service = new LeafletService( $imageRepo );
+		$service = $this->newService( $imageRepo );
 
 		$method = new ReflectionMethod( LeafletService::class, 'getJsImageLayers' );
 		$method->setAccessible( true );

--- a/tests/Unit/LeafletServiceTest.php
+++ b/tests/Unit/LeafletServiceTest.php
@@ -104,6 +104,20 @@ class LeafletServiceTest extends TestCase {
 		);
 	}
 
+	public function testNumericallyNamedCustomLayerSurvivesFiltering() {
+		$mapData = $this->newLeafletMapData(
+			[ 'layers' => [ 'OpenStreetMap', '1904' ] ],
+			new LeafletLayerDefinitions( [
+				'1904' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ],
+			] )
+		);
+
+		$this->assertSame(
+			[ 'OpenStreetMap', '1904' ],
+			$mapData->getParameters()['layers']
+		);
+	}
+
 	public function testCustomOverlayDefinitionSurvivesFiltering() {
 		$mapData = $this->newLeafletMapData(
 			[ 'overlays' => [ 'OpenSeaMap', 'Historic', '<img src=x onerror="alert(1)">' ] ],

--- a/tests/Unit/Map/CargoFormat/CargoOutputBuilderTest.php
+++ b/tests/Unit/Map/CargoFormat/CargoOutputBuilderTest.php
@@ -7,6 +7,7 @@ namespace Maps\Tests\Unit\Map\CargoFormat;
 use DataValues\Geo\Values\LatLongValue;
 use Maps\Map\CargoFormat\CargoOutputBuilder;
 use Maps\Map\Marker;
+use Maps\LeafletLayerDefinitions;
 use Maps\LeafletService;
 use Maps\Map\MapOutputBuilder;
 use Maps\MappingServices;
@@ -52,7 +53,7 @@ class CargoOutputBuilderTest extends TestCase {
 	}
 
 	private function callSetIconUrl( InMemoryImageRepository $imageRepo, array $markers, string $iconParameter ): void {
-		$leafletService = new LeafletService( new InMemoryImageRepository() );
+		$leafletService = new LeafletService( new InMemoryImageRepository(), new LeafletLayerDefinitions( [] ) );
 
 		$builder = new CargoOutputBuilder(
 			new MapOutputBuilder(),

--- a/tests/js/leaflet/JQueryLeafletTest.js
+++ b/tests/js/leaflet/JQueryLeafletTest.js
@@ -246,4 +246,194 @@
 		jqueryMap.map.remove();
 	} );
 
+	QUnit.test( 'getLayerDefinition returns null when options.layerDefinitions is absent', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var options = makeDefaultOptions();
+
+		var jqueryMap = createTestMap( $div, options );
+
+		assert.strictEqual(
+			jqueryMap.getLayerDefinition( 'OpenStreetMap' ),
+			null,
+			'Absent layerDefinitions yields null without error'
+		);
+
+		jqueryMap.map.remove();
+	} );
+
+	QUnit.test( 'getLayerDefinition returns the definition only for a matching name', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var options = makeDefaultOptions( {
+			layerDefinitions: {
+				Historic: { url: 'https://tiles.example/{z}/{x}/{y}.png', options: {}, wms: false }
+			}
+		} );
+
+		var jqueryMap = createTestMap( $div, options );
+
+		assert.strictEqual( jqueryMap.getLayerDefinition( 'OpenStreetMap' ), null, 'Unknown name yields null' );
+		assert.strictEqual(
+			jqueryMap.getLayerDefinition( 'Historic' ).url,
+			'https://tiles.example/{z}/{x}/{y}.png',
+			'Known name yields its definition'
+		);
+
+		jqueryMap.map.remove();
+	} );
+
+	QUnit.test( 'newBaseLayerFromName builds a tile layer from a custom definition', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var options = makeDefaultOptions( {
+			layers: [ 'Historic' ],
+			layerDefinitions: {
+				Historic: {
+					url: 'https://tiles.example/{z}/{x}/{y}.png',
+					options: { attribution: 'Example', maxZoom: 18 },
+					wms: false
+				}
+			}
+		} );
+
+		var jqueryMap = createTestMap( $div, options );
+
+		var capturedUrl = null;
+		var capturedOptions = null;
+		var sentinel = {};
+		var originalTileLayer = L.tileLayer;
+		L.tileLayer = function ( url, opts ) {
+			capturedUrl = url;
+			capturedOptions = opts;
+			return sentinel;
+		};
+		L.tileLayer.provider = originalTileLayer.provider;
+		L.tileLayer.wms = originalTileLayer.wms;
+
+		var layer;
+		try {
+			layer = jqueryMap.newBaseLayerFromName( 'Historic' );
+		} finally {
+			L.tileLayer = originalTileLayer;
+			jqueryMap.map.remove();
+		}
+
+		assert.strictEqual( layer, sentinel, 'Returns the layer built from the definition' );
+		assert.strictEqual( capturedUrl, 'https://tiles.example/{z}/{x}/{y}.png', 'Uses the definition url' );
+		assert.deepEqual(
+			capturedOptions,
+			{ attribution: 'Example', maxZoom: 18 },
+			'Passes the definition options through to Leaflet'
+		);
+	} );
+
+	QUnit.test( 'newBaseLayerFromName uses L.tileLayer.wms for a WMS definition', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var options = makeDefaultOptions( {
+			layers: [ 'Weather' ],
+			layerDefinitions: {
+				Weather: {
+					url: 'https://example/wms',
+					options: { layers: 'hist1904', transparent: true },
+					wms: true
+				}
+			}
+		} );
+
+		var jqueryMap = createTestMap( $div, options );
+
+		var capturedUrl = null;
+		var capturedOptions = null;
+		var sentinel = {};
+		var originalWms = L.tileLayer.wms;
+		L.tileLayer.wms = function ( url, opts ) {
+			capturedUrl = url;
+			capturedOptions = opts;
+			return sentinel;
+		};
+
+		var layer;
+		try {
+			layer = jqueryMap.newBaseLayerFromName( 'Weather' );
+		} finally {
+			L.tileLayer.wms = originalWms;
+			jqueryMap.map.remove();
+		}
+
+		assert.strictEqual( layer, sentinel, 'Returns the WMS layer built from the definition' );
+		assert.strictEqual( capturedUrl, 'https://example/wms', 'Uses the definition url' );
+		assert.deepEqual(
+			capturedOptions,
+			{ layers: 'hist1904', transparent: true },
+			'Passes the WMS options through to Leaflet'
+		);
+	} );
+
+	QUnit.test( 'newBaseLayerFromName falls back to the provider catalog without a matching definition', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var options = makeDefaultOptions( {
+			layers: [ 'OpenStreetMap' ],
+			layerDefinitions: {
+				Historic: { url: 'https://tiles.example/{z}/{x}/{y}.png', options: {}, wms: false }
+			}
+		} );
+
+		var jqueryMap = createTestMap( $div, options );
+
+		var capturedName = null;
+		var sentinel = { addTo: function () { return this; } };
+		var originalProvider = L.tileLayer.provider;
+		L.tileLayer.provider = function ( name ) {
+			capturedName = name;
+			return sentinel;
+		};
+
+		try {
+			jqueryMap.newBaseLayerFromName( 'OpenStreetMap' );
+		} finally {
+			L.tileLayer.provider = originalProvider;
+			jqueryMap.map.remove();
+		}
+
+		assert.strictEqual( capturedName, 'OpenStreetMap', 'Names without a definition use the provider catalog' );
+	} );
+
+	QUnit.test( 'addOverlays builds a custom overlay from its definition', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var options = makeDefaultOptions( {
+			overlays: [ 'HistoricOverlay' ],
+			layerDefinitions: {
+				HistoricOverlay: { url: 'https://tiles.example/{z}/{x}/{y}.png', options: {}, wms: false }
+			}
+		} );
+
+		var jqueryMap = createTestMap( $div, options );
+
+		var capturedUrl = null;
+		var sentinel = { addTo: function () { return this; } };
+		var originalTileLayer = L.tileLayer;
+		L.tileLayer = function ( url ) {
+			capturedUrl = url;
+			return sentinel;
+		};
+		L.tileLayer.provider = originalTileLayer.provider;
+		L.tileLayer.wms = originalTileLayer.wms;
+
+		var overlays;
+		try {
+			overlays = jqueryMap.addOverlays();
+		} finally {
+			L.tileLayer = originalTileLayer;
+			jqueryMap.map.remove();
+		}
+
+		assert.strictEqual(
+			capturedUrl,
+			'https://tiles.example/{z}/{x}/{y}.png',
+			'Custom overlay is built from its definition url'
+		);
+		assert.true(
+			Object.prototype.hasOwnProperty.call( overlays, 'HistoricOverlay' ),
+			'Overlay is keyed by its name'
+		);
+	} );
+
 }( window.jQuery, window.mediaWiki ) );


### PR DESCRIPTION
Adds the `$egMapsLeafletLayerDefinitions` setting for custom named Leaflet tile and WMS layers. Each
definition's name becomes a valid value of the `layers` and `overlays` parameters — in `#display_map` /
`format=leaflet` maps and query result formats alike. Only the definitions a map actually uses are
serialized to the client.
