### PR TITLE
Add on-wiki JSON config page for Leaflet layer settings

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -26,6 +26,12 @@ return [
 	// Allows disabling the Semantic MediaWiki integration.
 	'egMapsDisableSmwIntegration' => false,
 
+	// Boolean. Whether Maps configuration may also be set on the MediaWiki:Maps JSON config page,
+	// which is editable only by users with the editinterface and editsitejson rights. When false,
+	// that page is never read and only LocalSettings.php applies. The wiki page currently exposes
+	// the Leaflet layer settings; its values take precedence over LocalSettings.php.
+	'egMapsEnableInWikiConfig' => true,
+
 
 
 
@@ -255,14 +261,22 @@ return [
 	// Custom named tile layers that can be used as base layers or overlays, in addition to the
 	// stock leaflet-providers layers listed above. The name of each definition becomes a valid
 	// value for the layers and overlays parameters. Only the definitions actually used by a map
-	// are sent to the browser.
+	// are sent to the browser. The same layers can be defined on-wiki via the MediaWiki:Maps
+	// config page (see egMapsEnableInWikiConfig).
 	//
-	// Each definition has a 'url' (required, an XYZ tile template or, for WMS, the service
-	// endpoint), an optional 'options' array passed straight to Leaflet, and an optional 'wms'
-	// flag. Definitions without a non-empty url string are ignored.
+	// Each definition has a required 'url' plus optional 'options' and 'wms' entries:
+	//   - 'url' must be an http(s) URL. XYZ tile templates ({z}, {x}, {y}, {s}) and, for WMS, the
+	//     service endpoint are supported. Definitions without a valid url are ignored.
+	//   - 'wms' (boolean) renders the layer with L.tileLayer.wms instead of L.tileLayer.
+	//   - 'options' is passed to Leaflet, but only a safe allowlist of keys is kept: attribution,
+	//     minZoom, maxZoom, minNativeZoom, maxNativeZoom, subdomains, errorTileUrl, zoomOffset,
+	//     zoomReverse, tms, detectRetina, bounds, opacity, zIndex and noWrap; plus, for WMS layers,
+	//     layers, styles, format, transparent, version and uppercase. Unknown options are dropped.
+	//     'errorTileUrl' must be an http(s) URL, and 'attribution' is sanitized to plain text and
+	//     http(s) links.
 	//
 	// A definition whose name matches a stock layer (e.g. 'OpenStreetMap') overrides that stock
-	// layer. The 'options' are passed to Leaflet as-is; note that 'attribution' is rendered as HTML.
+	// layer.
 	//
 	// Example:
 	// 'egMapsLeafletLayerDefinitions' => [

--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@ via [Professional.Wiki](https://professional.wiki/). Discounts for work that is 
 * Ask a question on [the mailing list](https://www.semantic-mediawiki.org/wiki/Mailing_list)
 * File an issue on [our issue tracker](https://github.com/JeroenDeDauw/Maps/issues)
 
+## On-wiki configuration
+
+Most settings are configured in `LocalSettings.php` (see the
+[configuration documentation](https://maps.extension.wiki/wiki/Configuration)). Wiki administrators
+without server access can also configure the Leaflet layers on the `MediaWiki:Maps` page. It holds
+JSON and, like other site configuration, is editable only by users with the `editinterface` and
+`editsitejson` rights. For example, to add a custom tile layer that authors can then select with the
+`layers` parameter:
+
+```json
+{
+	"leaflet": {
+		"layerDefinitions": {
+			"Historic 1904": {
+				"url": "https://tiles.example.org/historic1904/{z}/{x}/{y}.png",
+				"options": { "attribution": "Historic map tiles", "maxZoom": 18 }
+			}
+		}
+	}
+}
+```
+
+The page is validated when saved and combined with `LocalSettings.php`, with the wiki page taking
+precedence. Changes take effect the next time a page with a map is parsed.
+
 ## Project status
 
 * Latest version [![Latest Stable Version](https://poser.pugx.org/mediawiki/maps/v/stable)](https://packagist.org/packages/mediawiki/maps)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,13 @@ different releases and which versions of PHP and MediaWiki they support, see the
 [platform compatibility tables](INSTALL.md#platform-compatibility-and-release-status).
 
 
+## Maps 14.0.0
+
+Released on TBD.
+
+* Added an on-wiki JSON configuration page at `MediaWiki:Maps` for the Leaflet layer settings (custom layer definitions, the default and available base layers and overlays). It is editable only by administrators and interface administrators, is validated on save, and is combined with `LocalSettings.php` with the wiki page taking precedence. Set `$egMapsEnableInWikiConfig` to `false` to disable it.
+* Hardened the custom Leaflet layer definitions used by `$egMapsLeafletLayerDefinitions` and the config page (breaking change): the `url` and `errorTileUrl` must be `http(s)` URLs, only an allowlist of Leaflet `options` is kept, and `attribution` is sanitized to plain text and `http(s)` links. Definitions relying on raw HTML attribution or non-allowlisted options need updating.
+
 ## Maps 13.1.0
 
 Released on July 19th, 2026.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -265,5 +265,18 @@
 	"maps-validator-describe-header-description": "Description",
 	"maps-validator-describe-required": "required",
 	"maps-validator-describe-empty": "empty",
-	"maps-validator-message-nodesc": "No description provided"
+	"maps-validator-message-nodesc": "No description provided",
+	"maps-config-invalid": "The Maps configuration was not saved because it is invalid:",
+	"maps-config-error-invalid-json": "The configuration must be a JSON object.",
+	"maps-config-error-not-object": "The value of \"$1\" must be a JSON object.",
+	"maps-config-error-unknown-key": "Unknown configuration key \"$1\".",
+	"maps-config-error-invalid-layer-name": "\"$1\" is not a valid layer name.",
+	"maps-config-error-unknown-layer-key": "Layer \"$1\" has an unknown property \"$2\".",
+	"maps-config-error-invalid-url": "Layer \"$1\" must have a \"url\" that starts with http:// or https://.",
+	"maps-config-error-invalid-wms": "The \"wms\" property of layer \"$1\" must be true or false.",
+	"maps-config-error-unknown-option": "Layer \"$1\" has an unknown option \"$2\".",
+	"maps-config-error-invalid-option-url": "The \"$2\" option of layer \"$1\" must be a URL that starts with http:// or https://.",
+	"maps-config-error-invalid-attribution": "The \"attribution\" option of layer \"$1\" must be text.",
+	"maps-config-error-invalid-default-list": "\"$1\" must be a list of layer names.",
+	"maps-config-error-invalid-availability": "\"$1\" must be a map of layer names to true or false."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -243,5 +243,18 @@
 	"maps-validator-describe-header-description": "{{Identical|Description}}\n{{Related|Validator-describe}}",
 	"maps-validator-describe-required": "{{related|Validator-describe}}\n{{Identical|Required}}",
 	"maps-validator-describe-empty": "{{Identical|Empty}}\n{{related|Validator-describe}}",
-	"maps-validator-message-nodesc": "Indicates that no parameter description is available"
+	"maps-validator-message-nodesc": "Indicates that no parameter description is available",
+	"maps-config-invalid": "Heading shown above the list of errors when an edit to the MediaWiki:Maps JSON config page is rejected.",
+	"maps-config-error-invalid-json": "Error shown when the MediaWiki:Maps config is not a JSON object.",
+	"maps-config-error-not-object": "Error shown when a value that must be a JSON object is not. $1 is the location, e.g. \"leaflet\" or \"layerDefinitions\".",
+	"maps-config-error-unknown-key": "Error shown when the config contains an unrecognized key. $1 is the unknown key.",
+	"maps-config-error-invalid-layer-name": "Error shown when a custom Leaflet layer has an invalid name. $1 is the name.",
+	"maps-config-error-unknown-layer-key": "Error shown when a custom Leaflet layer definition has an unrecognized property. $1 is the layer name, $2 is the property.",
+	"maps-config-error-invalid-url": "Error shown when a custom Leaflet layer has no valid url. $1 is the layer name.",
+	"maps-config-error-invalid-wms": "Error shown when the wms property of a custom Leaflet layer is not a boolean. $1 is the layer name.",
+	"maps-config-error-unknown-option": "Error shown when a custom Leaflet layer has an option that is not allowed. $1 is the layer name, $2 is the option.",
+	"maps-config-error-invalid-option-url": "Error shown when a URL option of a custom Leaflet layer is not a valid URL. $1 is the layer name, $2 is the option.",
+	"maps-config-error-invalid-attribution": "Error shown when the attribution option of a custom Leaflet layer is not text. $1 is the layer name.",
+	"maps-config-error-invalid-default-list": "Error shown when a default layer list is not a list of strings. $1 is defaultLayers or defaultOverlays.",
+	"maps-config-error-invalid-availability": "Error shown when a layer availability map is invalid. $1 is availableLayers or availableOverlays."
 }

--- a/src/AttributionSanitizer.php
+++ b/src/AttributionSanitizer.php
@@ -1,0 +1,92 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps;
+
+use DOMDocument;
+use DOMElement;
+
+/**
+ * Sanitizes a Leaflet layer attribution string so that it is safe to render as HTML.
+ *
+ * Leaflet inserts the attribution into the map via innerHTML, so untrusted markup here is a
+ * stored-XSS vector (see advisory GHSA-4h7g-5542-v3fc). The allowlist is deliberately narrow:
+ * plain text plus <a> links with an http(s) href and an optional title. Everything else, including
+ * <img>, event handlers and javascript:/data:/vbscript: hrefs, is removed. The text content of
+ * disallowed tags is kept as inert text.
+ *
+ * @licence GNU GPL v2+
+ */
+class AttributionSanitizer {
+
+	public function sanitize( string $attribution ): string {
+		if ( strpos( $attribution, '<' ) === false ) {
+			return $attribution;
+		}
+
+		$onlyAnchors = strip_tags( $attribution, '<a>' );
+
+		if ( strpos( $onlyAnchors, '<' ) === false ) {
+			return $onlyAnchors;
+		}
+
+		return $this->cleanAnchors( $onlyAnchors );
+	}
+
+	private function cleanAnchors( string $html ): string {
+		$document = new DOMDocument();
+
+		$previousErrorHandling = libxml_use_internal_errors( true );
+		$loaded = $document->loadHTML(
+			'<?xml encoding="UTF-8"?><div>' . $html . '</div>',
+			LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+		);
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previousErrorHandling );
+
+		if ( !$loaded || $document->documentElement === null ) {
+			return strip_tags( $html );
+		}
+
+		foreach ( $document->getElementsByTagName( 'a' ) as $anchor ) {
+			$this->cleanAnchor( $anchor );
+		}
+
+		return $this->innerHtml( $document->documentElement );
+	}
+
+	private function cleanAnchor( DOMElement $anchor ): void {
+		$href = $anchor->getAttribute( 'href' );
+		$title = $anchor->getAttribute( 'title' );
+
+		foreach ( iterator_to_array( $anchor->attributes ) as $attribute ) {
+			$anchor->removeAttribute( $attribute->name );
+		}
+
+		if ( $this->isAllowedHref( $href ) ) {
+			$anchor->setAttribute( 'href', $href );
+		}
+
+		if ( $title !== '' ) {
+			$anchor->setAttribute( 'title', $title );
+		}
+	}
+
+	private function isAllowedHref( string $href ): bool {
+		$normalized = strtolower( (string)preg_replace( '/[\x00-\x20]+/', '', $href ) );
+
+		return preg_match( '#^https?://#', $normalized ) === 1;
+	}
+
+	private function innerHtml( DOMElement $element ): string {
+		$html = '';
+
+		foreach ( $element->childNodes as $child ) {
+			$html .= $element->ownerDocument->saveHTML( $child );
+		}
+
+		return $html;
+	}
+
+}

--- a/src/CombiningLeafletConfigLookup.php
+++ b/src/CombiningLeafletConfigLookup.php
@@ -1,0 +1,115 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps;
+
+/**
+ * Resolves the effective Leaflet configuration by combining the PHP settings with the
+ * MediaWiki:Maps config page, with the wiki page taking precedence:
+ *
+ * * Layer definitions and availability maps are merged per name, the wiki value winning on
+ *   collision.
+ * * The default layer and overlay selections are replaced wholesale when the wiki page sets them.
+ *
+ * The wiki page is read lazily on first use and the result is memoized for the request. When wiki
+ * config is disabled, or the page is missing or unreadable, the PHP settings are used unchanged.
+ *
+ * @licence GNU GPL v2+
+ */
+class CombiningLeafletConfigLookup implements LeafletConfigLookup {
+
+	private ?LeafletConfig $config = null;
+
+	/**
+	 * @param array{
+	 *     layerDefinitions: array,
+	 *     defaultLayers: string[],
+	 *     defaultOverlays: string[],
+	 *     availableLayers: array<string, bool>,
+	 *     availableOverlays: array<string, bool>
+	 * } $phpConfig
+	 */
+	public function __construct(
+		private array $phpConfig,
+		private LeafletConfigSource $wikiConfigSource,
+		private bool $wikiConfigEnabled
+	) {
+	}
+
+	public function getConfig(): LeafletConfig {
+		$this->config ??= $this->buildConfig();
+
+		return $this->config;
+	}
+
+	private function buildConfig(): LeafletConfig {
+		$raw = $this->phpConfig;
+
+		if ( $this->wikiConfigEnabled ) {
+			$wikiConfig = $this->wikiConfigSource->getLeafletConfig();
+
+			if ( $wikiConfig !== null ) {
+				$raw = $this->combine( $this->phpConfig, $wikiConfig );
+			}
+		}
+
+		return new LeafletConfig(
+			new LeafletLayerDefinitions( $raw['layerDefinitions'] ),
+			$raw['defaultLayers'],
+			$raw['defaultOverlays'],
+			$raw['availableLayers'],
+			$raw['availableOverlays']
+		);
+	}
+
+	private function combine( array $php, array $wiki ): array {
+		return [
+			'layerDefinitions' => $this->mergeByName( $php['layerDefinitions'], $wiki['layerDefinitions'] ?? null ),
+			'defaultLayers' => $this->stringList( $wiki['defaultLayers'] ?? null ) ?? $php['defaultLayers'],
+			'defaultOverlays' => $this->stringList( $wiki['defaultOverlays'] ?? null ) ?? $php['defaultOverlays'],
+			'availableLayers' => $this->mergeAvailability( $php['availableLayers'], $wiki['availableLayers'] ?? null ),
+			'availableOverlays' => $this->mergeAvailability( $php['availableOverlays'], $wiki['availableOverlays'] ?? null ),
+		];
+	}
+
+	private function mergeByName( array $php, mixed $wiki ): array {
+		if ( !is_array( $wiki ) ) {
+			return $php;
+		}
+
+		// Union rather than array_merge: array_merge renumbers integer-like keys, which would drop
+		// a custom layer whose name is purely numeric (e.g. "1904"). Wiki entries go on the left so
+		// they take precedence over a same-named PHP entry.
+		return $wiki + $php;
+	}
+
+	private function mergeAvailability( array $php, mixed $wiki ): array {
+		if ( !is_array( $wiki ) ) {
+			return $php;
+		}
+
+		$coerced = [];
+
+		foreach ( $wiki as $name => $enabled ) {
+			$coerced[$name] = (bool)$enabled;
+		}
+
+		return $coerced + $php;
+	}
+
+	private function stringList( mixed $value ): ?array {
+		if ( !is_array( $value ) ) {
+			return null;
+		}
+
+		foreach ( $value as $item ) {
+			if ( !is_string( $item ) ) {
+				return null;
+			}
+		}
+
+		return array_values( $value );
+	}
+
+}

--- a/src/DataAccess/WikiLeafletConfigSource.php
+++ b/src/DataAccess/WikiLeafletConfigSource.php
@@ -1,0 +1,56 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\DataAccess;
+
+use Maps\LeafletConfigSource;
+use MediaWiki\Content\JsonContent;
+use MediaWiki\Json\FormatJson;
+
+/**
+ * Reads the raw Leaflet configuration from the MediaWiki:Maps JSON config page.
+ *
+ * Returns the decoded "leaflet" section, or null when the page is missing, is not JSON, cannot be
+ * decoded, or the database is unavailable (such as during installation). Validation and hardening
+ * of the returned data happen downstream, so this only needs to decode the page defensively.
+ *
+ * @licence GNU GPL v2+
+ */
+class WikiLeafletConfigSource implements LeafletConfigSource {
+
+	public function __construct(
+		private PageContentFetcher $contentFetcher,
+		private string $configPageName
+	) {
+	}
+
+	public function getLeafletConfig(): ?array {
+		$data = $this->getPageData();
+
+		if ( $data === null ) {
+			return null;
+		}
+
+		$leaflet = $data['leaflet'] ?? null;
+
+		return is_array( $leaflet ) ? $leaflet : null;
+	}
+
+	private function getPageData(): ?array {
+		try {
+			$content = $this->contentFetcher->getPageContent( $this->configPageName, NS_MEDIAWIKI );
+		} catch ( \Throwable $e ) {
+			return null;
+		}
+
+		if ( !$content instanceof JsonContent ) {
+			return null;
+		}
+
+		$decoded = FormatJson::decode( $content->getText(), true );
+
+		return is_array( $decoded ) ? $decoded : null;
+	}
+
+}

--- a/src/DataAccess/WikiLeafletConfigSource.php
+++ b/src/DataAccess/WikiLeafletConfigSource.php
@@ -7,6 +7,7 @@ namespace Maps\DataAccess;
 use Maps\LeafletConfigSource;
 use MediaWiki\Content\JsonContent;
 use MediaWiki\Json\FormatJson;
+use Throwable;
 
 /**
  * Reads the raw Leaflet configuration from the MediaWiki:Maps JSON config page.
@@ -40,7 +41,7 @@ class WikiLeafletConfigSource implements LeafletConfigSource {
 	private function getPageData(): ?array {
 		try {
 			$content = $this->contentFetcher->getPageContent( $this->configPageName, NS_MEDIAWIKI );
-		} catch ( \Throwable $e ) {
+		} catch ( Throwable $e ) {
 			return null;
 		}
 

--- a/src/LeafletConfig.php
+++ b/src/LeafletConfig.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps;
+
+/**
+ * The resolved Leaflet layer configuration consumed by LeafletService, after combining the PHP
+ * settings with the MediaWiki:Maps config page.
+ *
+ * @licence GNU GPL v2+
+ */
+class LeafletConfig {
+
+	/**
+	 * @param array<string, bool> $availableLayers
+	 * @param array<string, bool> $availableOverlays
+	 * @param string[] $defaultLayers
+	 * @param string[] $defaultOverlays
+	 */
+	public function __construct(
+		private LeafletLayerDefinitions $layerDefinitions,
+		private array $defaultLayers,
+		private array $defaultOverlays,
+		private array $availableLayers,
+		private array $availableOverlays
+	) {
+	}
+
+	public function getLayerDefinitions(): LeafletLayerDefinitions {
+		return $this->layerDefinitions;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getDefaultLayers(): array {
+		return $this->defaultLayers;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getDefaultOverlays(): array {
+		return $this->defaultOverlays;
+	}
+
+	/**
+	 * @return array<string, bool>
+	 */
+	public function getAvailableLayers(): array {
+		return $this->availableLayers;
+	}
+
+	/**
+	 * @return array<string, bool>
+	 */
+	public function getAvailableOverlays(): array {
+		return $this->availableOverlays;
+	}
+
+}

--- a/src/LeafletConfigLookup.php
+++ b/src/LeafletConfigLookup.php
@@ -1,0 +1,14 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps;
+
+/**
+ * @licence GNU GPL v2+
+ */
+interface LeafletConfigLookup {
+
+	public function getConfig(): LeafletConfig;
+
+}

--- a/src/LeafletConfigSource.php
+++ b/src/LeafletConfigSource.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps;
+
+/**
+ * A source of raw (undhardened, unvalidated) Leaflet configuration, such as the MediaWiki:Maps
+ * config page.
+ *
+ * @licence GNU GPL v2+
+ */
+interface LeafletConfigSource {
+
+	/**
+	 * The decoded "leaflet" section of the config, or null when there is none.
+	 */
+	public function getLeafletConfig(): ?array;
+
+}

--- a/src/LeafletConfigValidator.php
+++ b/src/LeafletConfigValidator.php
@@ -1,0 +1,216 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps;
+
+/**
+ * Validates the JSON of the MediaWiki:Maps config page at save time, producing precise error
+ * messages. The schema is strict: unknown keys and options are rejected, mirroring the render-time
+ * hardening in LeafletLayerDefinitions (both build on LeafletLayerContract).
+ *
+ * Errors are returned as message specs: an array whose first element is a message key and whose
+ * remaining elements are the message parameters. An empty result means the config is valid.
+ *
+ * @licence GNU GPL v2+
+ */
+class LeafletConfigValidator {
+
+	public const ERROR_INVALID_JSON = 'maps-config-error-invalid-json';
+	public const ERROR_NOT_OBJECT = 'maps-config-error-not-object';
+	public const ERROR_UNKNOWN_KEY = 'maps-config-error-unknown-key';
+	public const ERROR_INVALID_LAYER_NAME = 'maps-config-error-invalid-layer-name';
+	public const ERROR_UNKNOWN_LAYER_KEY = 'maps-config-error-unknown-layer-key';
+	public const ERROR_INVALID_URL = 'maps-config-error-invalid-url';
+	public const ERROR_INVALID_WMS = 'maps-config-error-invalid-wms';
+	public const ERROR_UNKNOWN_OPTION = 'maps-config-error-unknown-option';
+	public const ERROR_INVALID_OPTION_URL = 'maps-config-error-invalid-option-url';
+	public const ERROR_INVALID_ATTRIBUTION = 'maps-config-error-invalid-attribution';
+	public const ERROR_INVALID_DEFAULT_LIST = 'maps-config-error-invalid-default-list';
+	public const ERROR_INVALID_AVAILABILITY = 'maps-config-error-invalid-availability';
+
+	private const LEAFLET_KEYS = [
+		'layerDefinitions',
+		'defaultLayers',
+		'defaultOverlays',
+		'availableLayers',
+		'availableOverlays',
+	];
+
+	private const DEFINITION_KEYS = [ 'url', 'options', 'wms' ];
+
+	/**
+	 * @return array[] List of message specs, each [ messageKey, ...params ]. Empty when valid.
+	 */
+	public function validate( string $json ): array {
+		$data = json_decode( $json, true );
+
+		if ( $data === null ) {
+			// Invalid JSON syntax is enforced by MediaWiki core for the JSON content model, so it
+			// is left to core. Only a literal null value is flagged here.
+			return trim( $json ) === 'null' ? [ [ self::ERROR_INVALID_JSON ] ] : [];
+		}
+
+		if ( !$this->isObject( $data ) ) {
+			return [ [ self::ERROR_INVALID_JSON ] ];
+		}
+
+		return $this->validateTopLevel( $data );
+	}
+
+	private function validateTopLevel( array $data ): array {
+		$errors = $this->unknownKeyErrors( $data, [ 'leaflet' ] );
+
+		if ( array_key_exists( 'leaflet', $data ) ) {
+			$errors = array_merge( $errors, $this->validateLeaflet( $data['leaflet'] ) );
+		}
+
+		return $errors;
+	}
+
+	private function validateLeaflet( mixed $leaflet ): array {
+		if ( !$this->isObject( $leaflet ) ) {
+			return [ [ self::ERROR_NOT_OBJECT, 'leaflet' ] ];
+		}
+
+		$errors = $this->unknownKeyErrors( $leaflet, self::LEAFLET_KEYS );
+
+		if ( array_key_exists( 'layerDefinitions', $leaflet ) ) {
+			$errors = array_merge( $errors, $this->validateLayerDefinitions( $leaflet['layerDefinitions'] ) );
+		}
+
+		foreach ( [ 'defaultLayers', 'defaultOverlays' ] as $key ) {
+			if ( array_key_exists( $key, $leaflet ) && !$this->isStringList( $leaflet[$key] ) ) {
+				$errors[] = [ self::ERROR_INVALID_DEFAULT_LIST, $key ];
+			}
+		}
+
+		foreach ( [ 'availableLayers', 'availableOverlays' ] as $key ) {
+			if ( array_key_exists( $key, $leaflet ) && !$this->isAvailabilityMap( $leaflet[$key] ) ) {
+				$errors[] = [ self::ERROR_INVALID_AVAILABILITY, $key ];
+			}
+		}
+
+		return $errors;
+	}
+
+	private function validateLayerDefinitions( mixed $definitions ): array {
+		if ( !$this->isObject( $definitions ) ) {
+			return [ [ self::ERROR_NOT_OBJECT, 'layerDefinitions' ] ];
+		}
+
+		$errors = [];
+
+		foreach ( $definitions as $name => $definition ) {
+			$name = (string)$name;
+
+			if ( LeafletLayerContract::isValidLayerName( $name ) ) {
+				$errors = array_merge( $errors, $this->validateDefinition( $name, $definition ) );
+			} else {
+				$errors[] = [ self::ERROR_INVALID_LAYER_NAME, $name ];
+			}
+		}
+
+		return $errors;
+	}
+
+	private function validateDefinition( string $name, mixed $definition ): array {
+		if ( !$this->isObject( $definition ) ) {
+			return [ [ self::ERROR_NOT_OBJECT, $name ] ];
+		}
+
+		$errors = [];
+
+		foreach ( array_keys( $definition ) as $key ) {
+			if ( !in_array( $key, self::DEFINITION_KEYS, true ) ) {
+				$errors[] = [ self::ERROR_UNKNOWN_LAYER_KEY, $name, (string)$key ];
+			}
+		}
+
+		$url = $definition['url'] ?? null;
+		if ( !is_string( $url ) || !LeafletLayerContract::isValidLayerUrl( $url ) ) {
+			$errors[] = [ self::ERROR_INVALID_URL, $name ];
+		}
+
+		if ( array_key_exists( 'wms', $definition ) && !is_bool( $definition['wms'] ) ) {
+			$errors[] = [ self::ERROR_INVALID_WMS, $name ];
+		}
+
+		if ( array_key_exists( 'options', $definition ) ) {
+			$errors = array_merge(
+				$errors,
+				$this->validateOptions( $name, $definition['options'], ( $definition['wms'] ?? false ) === true )
+			);
+		}
+
+		return $errors;
+	}
+
+	private function validateOptions( string $name, mixed $options, bool $wms ): array {
+		if ( !$this->isObject( $options ) ) {
+			return [ [ self::ERROR_NOT_OBJECT, $name . '.options' ] ];
+		}
+
+		$allowed = array_fill_keys( LeafletLayerContract::allowedOptions( $wms ), true );
+
+		$errors = [];
+
+		foreach ( $options as $key => $value ) {
+			if ( !isset( $allowed[$key] ) ) {
+				$errors[] = [ self::ERROR_UNKNOWN_OPTION, $name, (string)$key ];
+			} elseif ( $key === 'attribution' && !is_string( $value ) ) {
+				$errors[] = [ self::ERROR_INVALID_ATTRIBUTION, $name ];
+			} elseif ( in_array( $key, LeafletLayerContract::URL_OPTIONS, true )
+				&& ( !is_string( $value ) || !LeafletLayerContract::isValidLayerUrl( $value ) ) ) {
+				$errors[] = [ self::ERROR_INVALID_OPTION_URL, $name, (string)$key ];
+			}
+		}
+
+		return $errors;
+	}
+
+	private function unknownKeyErrors( array $object, array $allowedKeys ): array {
+		$errors = [];
+
+		foreach ( array_keys( $object ) as $key ) {
+			if ( !in_array( $key, $allowedKeys, true ) ) {
+				$errors[] = [ self::ERROR_UNKNOWN_KEY, (string)$key ];
+			}
+		}
+
+		return $errors;
+	}
+
+	private function isObject( mixed $value ): bool {
+		return is_array( $value ) && ( $value === [] || !array_is_list( $value ) );
+	}
+
+	private function isStringList( mixed $value ): bool {
+		if ( !is_array( $value ) || !array_is_list( $value ) ) {
+			return false;
+		}
+
+		foreach ( $value as $item ) {
+			if ( !is_string( $item ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private function isAvailabilityMap( mixed $value ): bool {
+		if ( !$this->isObject( $value ) ) {
+			return false;
+		}
+
+		foreach ( $value as $enabled ) {
+			if ( !is_bool( $enabled ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+}

--- a/src/LeafletLayerContract.php
+++ b/src/LeafletLayerContract.php
@@ -1,0 +1,89 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps;
+
+/**
+ * The shared contract for custom Leaflet layer definitions: which layer names, URLs and Leaflet
+ * options are permitted. Both the render-time normalization (LeafletLayerDefinitions) and the
+ * save-time validation of the on-wiki config page (LeafletConfigValidator) build on these rules,
+ * so the same restrictions apply to layers defined via $egMapsLeafletLayerDefinitions and via the
+ * MediaWiki:Maps config page.
+ *
+ * @licence GNU GPL v2+
+ */
+class LeafletLayerContract {
+
+	/**
+	 * Leaflet options accepted on any layer, matching the safe subset of L.TileLayer options.
+	 */
+	public const TILE_OPTIONS = [
+		'attribution',
+		'minZoom',
+		'maxZoom',
+		'minNativeZoom',
+		'maxNativeZoom',
+		'subdomains',
+		'errorTileUrl',
+		'zoomOffset',
+		'zoomReverse',
+		'tms',
+		'detectRetina',
+		'bounds',
+		'opacity',
+		'zIndex',
+		'noWrap',
+	];
+
+	/**
+	 * Additional options accepted only on WMS layers, matching L.TileLayer.WMS.
+	 */
+	public const WMS_OPTIONS = [
+		'layers',
+		'styles',
+		'format',
+		'transparent',
+		'version',
+		'uppercase',
+	];
+
+	/**
+	 * Options whose value must be an http(s) URL, validated like the layer url itself.
+	 */
+	public const URL_OPTIONS = [
+		'errorTileUrl',
+	];
+
+	/**
+	 * Layer names that are rejected to avoid JavaScript prototype pollution on the client.
+	 */
+	public const RESERVED_LAYER_NAMES = [
+		'__proto__',
+		'constructor',
+		'prototype',
+	];
+
+	public const MAX_LAYER_NAME_LENGTH = 200;
+
+	public const MAX_URL_LENGTH = 2000;
+
+	/**
+	 * @return string[]
+	 */
+	public static function allowedOptions( bool $wms ): array {
+		return $wms ? array_merge( self::TILE_OPTIONS, self::WMS_OPTIONS ) : self::TILE_OPTIONS;
+	}
+
+	public static function isValidLayerName( string $name ): bool {
+		return $name !== ''
+			&& mb_strlen( $name ) <= self::MAX_LAYER_NAME_LENGTH
+			&& !in_array( $name, self::RESERVED_LAYER_NAMES, true );
+	}
+
+	public static function isValidLayerUrl( string $url ): bool {
+		return strlen( $url ) <= self::MAX_URL_LENGTH
+			&& preg_match( '#^https?://#i', $url ) === 1;
+	}
+
+}

--- a/src/LeafletLayerDefinitions.php
+++ b/src/LeafletLayerDefinitions.php
@@ -5,13 +5,19 @@ declare( strict_types = 1 );
 namespace Maps;
 
 /**
- * Admin-defined custom Leaflet base and overlay layers, configured via
- * $egMapsLeafletLayerDefinitions. Normalizes and validates the raw configuration and is the
+ * Admin-defined custom Leaflet base and overlay layers, coming from $egMapsLeafletLayerDefinitions
+ * and/or the MediaWiki:Maps config page. Normalizes and hardens the raw configuration and is the
  * single source of truth for which custom layer names exist and what their definition is.
+ *
+ * Hardening (see LeafletLayerContract) is applied identically to both config sources: the url and
+ * errorTileUrl must be http(s) URLs, only allowlisted Leaflet options are kept, the attribution is
+ * sanitized, and layer names that are empty, too long or prototype-polluting are rejected.
  *
  * @licence GNU GPL v2+
  */
 class LeafletLayerDefinitions {
+
+	private AttributionSanitizer $attributionSanitizer;
 
 	/**
 	 * @var array<string, array{url: string, options: array, wms: bool}>
@@ -19,10 +25,10 @@ class LeafletLayerDefinitions {
 	private array $definitions;
 
 	/**
-	 * @param array $rawDefinitions Layer name to raw definition, as configured via
-	 *        $egMapsLeafletLayerDefinitions. Invalid definitions are skipped.
+	 * @param array $rawDefinitions Layer name to raw definition. Invalid definitions are skipped.
 	 */
 	public function __construct( array $rawDefinitions ) {
+		$this->attributionSanitizer = new AttributionSanitizer();
 		$this->definitions = $this->normalizeAll( $rawDefinitions );
 	}
 
@@ -30,6 +36,10 @@ class LeafletLayerDefinitions {
 		$definitions = [];
 
 		foreach ( $rawDefinitions as $name => $rawDefinition ) {
+			if ( !LeafletLayerContract::isValidLayerName( (string)$name ) ) {
+				continue;
+			}
+
 			$definition = $this->normalize( $rawDefinition );
 
 			if ( $definition !== null ) {
@@ -50,22 +60,53 @@ class LeafletLayerDefinitions {
 
 		$url = $rawDefinition['url'] ?? null;
 
-		if ( !is_string( $url ) || $url === '' ) {
+		if ( !is_string( $url ) || !LeafletLayerContract::isValidLayerUrl( $url ) ) {
 			return null;
 		}
 
+		$wms = (bool)( $rawDefinition['wms'] ?? false );
+
 		return [
 			'url' => $url,
-			'options' => is_array( $rawDefinition['options'] ?? null ) ? $rawDefinition['options'] : [],
-			'wms' => (bool)( $rawDefinition['wms'] ?? false ),
+			'options' => $this->normalizeOptions(
+				is_array( $rawDefinition['options'] ?? null ) ? $rawDefinition['options'] : [],
+				$wms
+			),
+			'wms' => $wms,
 		];
+	}
+
+	private function normalizeOptions( array $options, bool $wms ): array {
+		$allowed = array_fill_keys( LeafletLayerContract::allowedOptions( $wms ), true );
+
+		$normalized = [];
+
+		foreach ( $options as $key => $value ) {
+			if ( !isset( $allowed[$key] ) ) {
+				continue;
+			}
+
+			if ( $key === 'attribution' ) {
+				if ( is_string( $value ) ) {
+					$normalized[$key] = $this->attributionSanitizer->sanitize( $value );
+				}
+			} elseif ( in_array( $key, LeafletLayerContract::URL_OPTIONS, true ) ) {
+				if ( is_string( $value ) && LeafletLayerContract::isValidLayerUrl( $value ) ) {
+					$normalized[$key] = $value;
+				}
+			} else {
+				$normalized[$key] = $value;
+			}
+		}
+
+		return $normalized;
 	}
 
 	/**
 	 * @return string[]
 	 */
 	public function getLayerNames(): array {
-		return array_keys( $this->definitions );
+		return array_map( 'strval', array_keys( $this->definitions ) );
 	}
 
 	/**

--- a/src/LeafletService.php
+++ b/src/LeafletService.php
@@ -16,12 +16,20 @@ use ParamProcessor\ProcessingResult;
 class LeafletService implements MappingService {
 
 	private ImageRepository $imageFinder;
-	private LeafletLayerDefinitions $layerDefinitions;
+	private LeafletConfigLookup $configLookup;
 	private array $addedDependencies = [];
 
-	public function __construct( ImageRepository $imageFinder, LeafletLayerDefinitions $layerDefinitions ) {
+	public function __construct( ImageRepository $imageFinder, LeafletConfigLookup $configLookup ) {
 		$this->imageFinder = $imageFinder;
-		$this->layerDefinitions = $layerDefinitions;
+		$this->configLookup = $configLookup;
+	}
+
+	/**
+	 * Resolved lazily and memoized so the MediaWiki:Maps config page is only read at parse time,
+	 * never during extension setup.
+	 */
+	private function getConfig(): LeafletConfig {
+		return $this->configLookup->getConfig();
 	}
 
 	public function getName(): string {
@@ -53,8 +61,8 @@ class LeafletService implements MappingService {
 			'aliases' => 'layer',
 			'type' => 'string',
 			'islist' => true,
-			'values' => $this->availableLayerNames( $GLOBALS['egMapsLeafletAvailableLayers'] ),
-			'default' => $GLOBALS['egMapsLeafletLayers'],
+			'values' => $this->availableLayerNames( $this->getConfig()->getAvailableLayers() ),
+			'default' => $this->getConfig()->getDefaultLayers(),
 			'message' => 'maps-leaflet-par-layers',
 		];
 
@@ -70,8 +78,8 @@ class LeafletService implements MappingService {
 			'aliases' => [ 'overlaylayers' ],
 			'type' => ParameterTypes::STRING,
 			'islist' => true,
-			'values' => $this->availableLayerNames( $GLOBALS['egMapsLeafletAvailableOverlayLayers'] ),
-			'default' => $GLOBALS['egMapsLeafletOverlayLayers'],
+			'values' => $this->availableLayerNames( $this->getConfig()->getAvailableOverlays() ),
+			'default' => $this->getConfig()->getDefaultOverlays(),
 			'message' => 'maps-leaflet-par-overlaylayers',
 		];
 
@@ -159,7 +167,7 @@ class LeafletService implements MappingService {
 			array_unique(
 				array_merge(
 					array_keys( $availableStockLayers, true, true ),
-					$this->layerDefinitions->getLayerNames()
+					$this->getConfig()->getLayerDefinitions()->getLayerNames()
 				)
 			)
 		);
@@ -226,14 +234,15 @@ class LeafletService implements MappingService {
 	}
 
 	private function getLayerDependencies( array $params ) {
-		global $egMapsLeafletLayerDependencies, $egMapsLeafletAvailableLayers,
-			   $egMapsLeafletLayersApiKeys;
+		global $egMapsLeafletLayerDependencies, $egMapsLeafletLayersApiKeys;
+
+		$availableLayers = $this->getConfig()->getAvailableLayers();
 
 		$layerDependencies = [];
 
 		foreach ( $params['layers'] as $layerName ) {
-			if ( array_key_exists( $layerName, $egMapsLeafletAvailableLayers )
-				&& $egMapsLeafletAvailableLayers[$layerName]
+			if ( array_key_exists( $layerName, $availableLayers )
+				&& $availableLayers[$layerName]
 				&& array_key_exists( $layerName, $egMapsLeafletLayersApiKeys )
 				&& array_key_exists( $layerName, $egMapsLeafletLayerDependencies ) ) {
 				$layerDependencies[] = '<script src="' . $egMapsLeafletLayerDependencies[$layerName] .
@@ -263,11 +272,11 @@ class LeafletService implements MappingService {
 
 		$params['overlays'] = $this->filterToAvailable(
 			$params['overlays'],
-			$this->availableWithDefinitions( $GLOBALS['egMapsLeafletAvailableOverlayLayers'] )
+			$this->availableWithDefinitions( $this->getConfig()->getAvailableOverlays() )
 		);
 		$params['layers'] = $this->filterToAvailable(
 			$params['layers'],
-			$this->availableWithDefinitions( $GLOBALS['egMapsLeafletAvailableLayers'] )
+			$this->availableWithDefinitions( $this->getConfig()->getAvailableLayers() )
 		);
 
 		$params = $this->addUsedLayerDefinitions( $params );
@@ -301,7 +310,7 @@ class LeafletService implements MappingService {
 		// Union rather than array_merge: array_merge renumbers integer-like keys, which would drop
 		// a custom layer whose name is purely numeric (e.g. "1904"). Custom names go on the left so
 		// they take precedence over a same-named stock layer.
-		return array_fill_keys( $this->layerDefinitions->getLayerNames(), true ) + $available;
+		return array_fill_keys( $this->getConfig()->getLayerDefinitions()->getLayerNames(), true ) + $available;
 	}
 
 	/**
@@ -309,7 +318,7 @@ class LeafletService implements MappingService {
 	 * the relevant definitions are shipped to the client rather than the whole catalog.
 	 */
 	private function addUsedLayerDefinitions( array $params ): array {
-		$usedDefinitions = $this->layerDefinitions->getDefinitions(
+		$usedDefinitions = $this->getConfig()->getLayerDefinitions()->getDefinitions(
 			array_merge( $params['layers'], $params['overlays'] )
 		);
 

--- a/src/MapsFactory.php
+++ b/src/MapsFactory.php
@@ -20,6 +20,7 @@ use Maps\DataAccess\MapsFileFetcher;
 use Maps\DataAccess\MediaWikiFileUrlFinder;
 use Maps\DataAccess\MwImageRepository;
 use Maps\DataAccess\PageContentFetcher;
+use Maps\DataAccess\WikiLeafletConfigSource;
 use Maps\GeoJsonPages\GeoJsonStore;
 use Maps\GeoJsonPages\Semantic\SemanticGeoJsonStore;
 use Maps\GeoJsonPages\Semantic\SubObjectBuilder;
@@ -50,6 +51,11 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
  */
 class MapsFactory {
 
+	/**
+	 * The page in the MediaWiki namespace holding the on-wiki JSON configuration.
+	 */
+	public const CONFIG_PAGE_TITLE = 'Maps';
+
 	protected static ?self $globalInstance = null;
 
 	private array $settings;
@@ -57,6 +63,7 @@ class MapsFactory {
 
 	private LeafletService $leafletService;
 	private GoogleMapsService $googleService;
+	private ?LeafletConfigLookup $leafletConfigLookup = null;
 
 	final protected function __construct( array $settings, MediaWikiServices $mediaWikiServices ) {
 		$this->settings = $settings;
@@ -192,14 +199,43 @@ class MapsFactory {
 	private function getLeafletService(): LeafletService {
 		$this->leafletService ??= new LeafletService(
 			$this->getImageRepository(),
-			$this->getLeafletLayerDefinitions()
+			$this->getLeafletConfigLookup()
 		);
 
 		return $this->leafletService;
 	}
 
-	public function getLeafletLayerDefinitions(): LeafletLayerDefinitions {
-		return new LeafletLayerDefinitions( $this->settings['egMapsLeafletLayerDefinitions'] ?? [] );
+	public function getLeafletConfigLookup(): LeafletConfigLookup {
+		$this->leafletConfigLookup ??= new CombiningLeafletConfigLookup(
+			[
+				'layerDefinitions' => $this->settings['egMapsLeafletLayerDefinitions'] ?? [],
+				'defaultLayers' => $this->settings['egMapsLeafletLayers'] ?? [],
+				'defaultOverlays' => $this->settings['egMapsLeafletOverlayLayers'] ?? [],
+				'availableLayers' => $this->settings['egMapsLeafletAvailableLayers'] ?? [],
+				'availableOverlays' => $this->settings['egMapsLeafletAvailableOverlayLayers'] ?? [],
+			],
+			new WikiLeafletConfigSource( $this->getPageContentFetcher(), self::CONFIG_PAGE_TITLE ),
+			$this->isWikiConfigEnabled()
+		);
+
+		return $this->leafletConfigLookup;
+	}
+
+	public function getLeafletConfigValidator(): LeafletConfigValidator {
+		return new LeafletConfigValidator();
+	}
+
+	public function isWikiConfigEnabled(): bool {
+		return (bool)( $this->settings['egMapsEnableInWikiConfig'] ?? true );
+	}
+
+	/**
+	 * Whether the given title is the on-wiki config page and reading it is enabled.
+	 */
+	public function isConfigPage( Title $title ): bool {
+		return $this->isWikiConfigEnabled()
+			&& $title->getNamespace() === NS_MEDIAWIKI
+			&& $title->getText() === self::CONFIG_PAGE_TITLE;
 	}
 
 	public function getDisplayMapFunction(): DisplayMapFunction {

--- a/src/MapsFactory.php
+++ b/src/MapsFactory.php
@@ -214,11 +214,15 @@ class MapsFactory {
 				'availableLayers' => $this->settings['egMapsLeafletAvailableLayers'] ?? [],
 				'availableOverlays' => $this->settings['egMapsLeafletAvailableOverlayLayers'] ?? [],
 			],
-			new WikiLeafletConfigSource( $this->getPageContentFetcher(), self::CONFIG_PAGE_TITLE ),
+			$this->newWikiLeafletConfigSource(),
 			$this->isWikiConfigEnabled()
 		);
 
 		return $this->leafletConfigLookup;
+	}
+
+	protected function newWikiLeafletConfigSource(): LeafletConfigSource {
+		return new WikiLeafletConfigSource( $this->getPageContentFetcher(), self::CONFIG_PAGE_TITLE );
 	}
 
 	public function getLeafletConfigValidator(): LeafletConfigValidator {

--- a/src/MapsHooks.php
+++ b/src/MapsHooks.php
@@ -8,8 +8,10 @@ use AlItem;
 use ALTree;
 use Maps\GeoJsonPages\GeoJsonNewPageUi;
 use Maps\Presentation\OutputFacade;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Settings\SettingsBuilder;
+use MediaWiki\Title\Title;
 use SkinTemplate;
 use SMW\Query\PrintRequest;
 
@@ -117,6 +119,59 @@ final class MapsHooks {
 
 	public static function onChangeTagsAllowedAdd( array &$allowedTags ) {
 		$allowedTags[] = 'maps-visual-edit';
+	}
+
+	/**
+	 * Forces the JSON content model on the on-wiki config page, so MediaWiki core requires the
+	 * editinterface and editsitejson rights to edit it and enforces JSON syntax on save.
+	 *
+	 * @param Title $title
+	 * @param string &$model
+	 */
+	public static function onContentHandlerDefaultModelFor( $title, &$model ) {
+		if ( MapsFactory::globalInstance()->isConfigPage( $title ) ) {
+			$model = CONTENT_MODEL_JSON;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validates the on-wiki config page on save, blocking the edit with precise errors when the
+	 * configuration is invalid.
+	 *
+	 * @param \MediaWiki\EditPage\EditPage $editor
+	 * @param string $text
+	 * @param string $section
+	 * @param string &$error
+	 * @param string $summary
+	 */
+	public static function onEditFilter( $editor, $text, $section, &$error, $summary ) {
+		$factory = MapsFactory::globalInstance();
+
+		if ( !is_string( $text ) || !$factory->isConfigPage( $editor->getTitle() ) ) {
+			return true;
+		}
+
+		$errors = $factory->getLeafletConfigValidator()->validate( $text );
+
+		if ( $errors !== [] ) {
+			$error = self::formatConfigErrors( $errors );
+		}
+
+		return true;
+	}
+
+	private static function formatConfigErrors( array $errors ): string {
+		$items = '';
+
+		foreach ( $errors as $errorSpec ) {
+			$items .= Html::rawElement( 'li', [], wfMessage( ...$errorSpec )->escaped() );
+		}
+
+		return Html::errorBox(
+			wfMessage( 'maps-config-invalid' )->escaped() . Html::rawElement( 'ul', [], $items )
+		);
 	}
 
 	/**

--- a/src/MapsSetup.php
+++ b/src/MapsSetup.php
@@ -110,6 +110,8 @@ class MapsSetup {
 		$hooks['ListDefinedTags'][] = 'Maps\MapsHooks::onRegisterTags';
 		$hooks['ChangeTagsListActive'][] = 'Maps\MapsHooks::onRegisterTags';
 		$hooks['ChangeTagsAllowedAdd'][] = 'Maps\MapsHooks::onChangeTagsAllowedAdd';
+		$hooks['ContentHandlerDefaultModelFor'][] = 'Maps\MapsHooks::onContentHandlerDefaultModelFor';
+		$hooks['EditFilter'][] = 'Maps\MapsHooks::onEditFilter';
 
 		$hooks['CargoSetFormatClasses'][] = function( array &$formatClasses ) {
 			$formatClasses['map'] = CargoFormat::class;

--- a/tests/Integration/ConfigPageHooksTest.php
+++ b/tests/Integration/ConfigPageHooksTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\Integration;
+
+use Maps\MapsHooks;
+use Maps\Tests\MapsTestFactory;
+use MediaWiki\Title\Title;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Maps\MapsHooks::onContentHandlerDefaultModelFor
+ * @covers \Maps\MapsHooks::onEditFilter
+ */
+class ConfigPageHooksTest extends TestCase {
+
+	private bool $originalEnabled;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->originalEnabled = $GLOBALS['egMapsEnableInWikiConfig'] ?? true;
+		$this->setWikiConfigEnabled( true );
+	}
+
+	protected function tearDown(): void {
+		$this->setWikiConfigEnabled( $this->originalEnabled );
+
+		parent::tearDown();
+	}
+
+	private function setWikiConfigEnabled( bool $enabled ): void {
+		$GLOBALS['egMapsEnableInWikiConfig'] = $enabled;
+		MapsTestFactory::newTestInstance();
+	}
+
+	private function configTitle(): Title {
+		return Title::makeTitle( NS_MEDIAWIKI, 'Maps' );
+	}
+
+	private function editorFor( Title $title ): object {
+		return new class( $title ) {
+			public function __construct( private Title $title ) {
+			}
+
+			public function getTitle(): Title {
+				return $this->title;
+			}
+		};
+	}
+
+	public function testConfigPageGetsJsonContentModel() {
+		$model = CONTENT_MODEL_WIKITEXT;
+
+		MapsHooks::onContentHandlerDefaultModelFor( $this->configTitle(), $model );
+
+		$this->assertSame( CONTENT_MODEL_JSON, $model );
+	}
+
+	public function testOtherMediaWikiPageKeepsItsContentModel() {
+		$model = CONTENT_MODEL_WIKITEXT;
+
+		MapsHooks::onContentHandlerDefaultModelFor( Title::makeTitle( NS_MEDIAWIKI, 'NotMaps' ), $model );
+
+		$this->assertSame( CONTENT_MODEL_WIKITEXT, $model );
+	}
+
+	public function testContentModelIsNotForcedWhenWikiConfigDisabled() {
+		$this->setWikiConfigEnabled( false );
+
+		$model = CONTENT_MODEL_WIKITEXT;
+		MapsHooks::onContentHandlerDefaultModelFor( $this->configTitle(), $model );
+
+		$this->assertSame( CONTENT_MODEL_WIKITEXT, $model );
+	}
+
+	public function testValidConfigIsAccepted() {
+		$error = '';
+
+		MapsHooks::onEditFilter( $this->editorFor( $this->configTitle() ), '{"leaflet":{}}', '', $error, '' );
+
+		$this->assertSame( '', $error );
+	}
+
+	public function testInvalidConfigIsRejected() {
+		$error = '';
+
+		MapsHooks::onEditFilter(
+			$this->editorFor( $this->configTitle() ),
+			'{"leaflet":{"layerDefinitions":{"Historic":{"url":"ftp://tiles.example"}}}}',
+			'',
+			$error,
+			''
+		);
+
+		$this->assertNotSame( '', $error );
+	}
+
+	public function testEditsToOtherPagesAreNotValidated() {
+		$error = '';
+
+		MapsHooks::onEditFilter(
+			$this->editorFor( Title::makeTitle( NS_MAIN, 'Some page' ) ),
+			'this is not even json',
+			'',
+			$error,
+			''
+		);
+
+		$this->assertSame( '', $error );
+	}
+
+	public function testConfigPageIsNotValidatedWhenWikiConfigDisabled() {
+		$this->setWikiConfigEnabled( false );
+
+		$error = '';
+		MapsHooks::onEditFilter(
+			$this->editorFor( $this->configTitle() ),
+			'{"leaflet":{"layerDefinitions":{"Historic":{"url":"ftp://tiles.example"}}}}',
+			'',
+			$error,
+			''
+		);
+
+		$this->assertSame( '', $error );
+	}
+
+}

--- a/tests/Integration/Parser/LeafletTest.php
+++ b/tests/Integration/Parser/LeafletTest.php
@@ -4,9 +4,11 @@ declare( strict_types = 1 );
 
 namespace Maps\Tests\Integration\Parser;
 
+use Maps\LeafletConfig;
 use Maps\LeafletLayerDefinitions;
 use Maps\LeafletService;
 use Maps\Tests\MapsTestFactory;
+use Maps\Tests\TestDoubles\FixedLeafletConfigLookup;
 use Maps\Tests\TestDoubles\ImageValueObject;
 use Maps\Tests\TestDoubles\InMemoryImageRepository;
 use Maps\Tests\Util\TestFactory;
@@ -76,25 +78,28 @@ class LeafletTest extends TestCase {
 		$this->assertStringContainsData( '"height":50', $html );
 	}
 
-	public function testCustomLayerNameIsAValidLayerValue() {
-		$service = new LeafletService(
+	private function newServiceWithCustomLayer(): LeafletService {
+		return new LeafletService(
 			new InMemoryImageRepository(),
-			new LeafletLayerDefinitions( [ 'Historic' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ] ] )
+			new FixedLeafletConfigLookup( new LeafletConfig(
+				new LeafletLayerDefinitions( [ 'Historic' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ] ] ),
+				[ 'OpenStreetMap' ],
+				[],
+				[ 'OpenStreetMap' => true ],
+				[ 'OpenSeaMap' => true ]
+			) )
 		);
+	}
 
-		$values = $service->getParameterInfo()['layers']['values'];
+	public function testCustomLayerNameIsAValidLayerValue() {
+		$values = $this->newServiceWithCustomLayer()->getParameterInfo()['layers']['values'];
 
 		$this->assertContains( 'Historic', $values );
 		$this->assertContains( 'OpenStreetMap', $values );
 	}
 
 	public function testCustomLayerNameIsAValidOverlayValue() {
-		$service = new LeafletService(
-			new InMemoryImageRepository(),
-			new LeafletLayerDefinitions( [ 'Historic' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ] ] )
-		);
-
-		$values = $service->getParameterInfo()['overlays']['values'];
+		$values = $this->newServiceWithCustomLayer()->getParameterInfo()['overlays']['values'];
 
 		$this->assertContains( 'Historic', $values );
 		$this->assertContains( 'OpenSeaMap', $values );

--- a/tests/MapsTestFactory.php
+++ b/tests/MapsTestFactory.php
@@ -5,8 +5,10 @@ declare( strict_types = 1 );
 namespace Maps\Tests;
 
 use Maps\DataAccess\ImageRepository;
+use Maps\LeafletConfigSource;
 use Maps\MapsFactory;
 use Maps\Tests\TestDoubles\InMemoryImageRepository;
+use Maps\Tests\TestDoubles\StubLeafletConfigSource;
 
 class MapsTestFactory extends MapsFactory {
 
@@ -29,6 +31,14 @@ class MapsTestFactory extends MapsFactory {
 
 	public function getImageRepository(): ImageRepository {
 		return $this->imageRepo;
+	}
+
+	/**
+	 * Keeps tests hermetic: the config lookup uses the PHP settings only, without reading the
+	 * MediaWiki:Maps page from the database.
+	 */
+	protected function newWikiLeafletConfigSource(): LeafletConfigSource {
+		return new StubLeafletConfigSource( null );
 	}
 
 }

--- a/tests/TestDoubles/FixedLeafletConfigLookup.php
+++ b/tests/TestDoubles/FixedLeafletConfigLookup.php
@@ -1,0 +1,21 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\TestDoubles;
+
+use Maps\LeafletConfig;
+use Maps\LeafletConfigLookup;
+
+class FixedLeafletConfigLookup implements LeafletConfigLookup {
+
+	public function __construct(
+		private LeafletConfig $config
+	) {
+	}
+
+	public function getConfig(): LeafletConfig {
+		return $this->config;
+	}
+
+}

--- a/tests/TestDoubles/StubLeafletConfigSource.php
+++ b/tests/TestDoubles/StubLeafletConfigSource.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\TestDoubles;
+
+use Maps\LeafletConfigSource;
+
+class StubLeafletConfigSource implements LeafletConfigSource {
+
+	public function __construct(
+		private ?array $leafletConfig
+	) {
+	}
+
+	public function getLeafletConfig(): ?array {
+		return $this->leafletConfig;
+	}
+
+}

--- a/tests/TestDoubles/StubPageContentFetcher.php
+++ b/tests/TestDoubles/StubPageContentFetcher.php
@@ -1,0 +1,21 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\TestDoubles;
+
+use Maps\DataAccess\PageContentFetcher;
+use MediaWiki\Content\Content;
+
+class StubPageContentFetcher extends PageContentFetcher {
+
+	public function __construct(
+		private ?Content $content
+	) {
+	}
+
+	public function getPageContent( string $pageTitle, int $defaultNamespace = NS_MAIN ): ?Content {
+		return $this->content;
+	}
+
+}

--- a/tests/Unit/AttributionSanitizerTest.php
+++ b/tests/Unit/AttributionSanitizerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\Unit;
+
+use Maps\AttributionSanitizer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Maps\AttributionSanitizer
+ */
+class AttributionSanitizerTest extends TestCase {
+
+	private function sanitize( string $attribution ): string {
+		return ( new AttributionSanitizer() )->sanitize( $attribution );
+	}
+
+	public function testPlainTextIsUnchanged() {
+		$this->assertSame(
+			'Map data © OpenStreetMap contributors',
+			$this->sanitize( 'Map data © OpenStreetMap contributors' )
+		);
+	}
+
+	public function testPlainTextEntitiesArePreserved() {
+		$this->assertSame( 'Tiles &amp; data', $this->sanitize( 'Tiles &amp; data' ) );
+	}
+
+	public function testHttpsLinkIsKept() {
+		$html = $this->sanitize( '<a href="https://openstreetmap.org">OSM</a>' );
+
+		$this->assertStringContainsString( 'href="https://openstreetmap.org"', $html );
+		$this->assertStringContainsString( 'OSM', $html );
+	}
+
+	public function testHttpLinkIsKept() {
+		$this->assertStringContainsString(
+			'href="http://example.org"',
+			$this->sanitize( '<a href="http://example.org">Example</a>' )
+		);
+	}
+
+	public function testLinkTitleIsKept() {
+		$this->assertStringContainsString(
+			'title="OpenStreetMap"',
+			$this->sanitize( '<a href="https://openstreetmap.org" title="OpenStreetMap">OSM</a>' )
+		);
+	}
+
+	public function testImageTagIsStripped() {
+		$this->assertSame( '', $this->sanitize( '<img src=x onerror="alert(1)">' ) );
+	}
+
+	public function testScriptTagIsReducedToInertText() {
+		$html = $this->sanitize( '<script>alert(1)</script>' );
+
+		$this->assertStringNotContainsString( '<script', $html );
+		$this->assertStringNotContainsString( '<', $html );
+	}
+
+	public function testJavascriptHrefIsStripped() {
+		$html = $this->sanitize( '<a href="javascript:alert(1)">click</a>' );
+
+		$this->assertStringNotContainsString( 'javascript', $html );
+		$this->assertStringContainsString( 'click', $html );
+	}
+
+	public function testObfuscatedJavascriptHrefIsStripped() {
+		$this->assertStringNotContainsString(
+			'alert(1)',
+			$this->sanitize( '<a href="java&#9;script:alert(1)">click</a>' )
+		);
+	}
+
+	public function testEntityEncodedColonInJavascriptHrefIsStripped() {
+		$this->assertStringNotContainsString(
+			'javascript',
+			$this->sanitize( '<a href="javascript&#58;alert(1)">click</a>' )
+		);
+	}
+
+	public function testUppercaseJavascriptHrefIsStripped() {
+		$this->assertStringNotContainsString(
+			'alert(1)',
+			$this->sanitize( '<a href="JAVASCRIPT:alert(1)">click</a>' )
+		);
+	}
+
+	public function testDataHrefIsStripped() {
+		$this->assertStringNotContainsString(
+			'data:',
+			$this->sanitize( '<a href="data:text/html;base64,PHN2Zz4=">click</a>' )
+		);
+	}
+
+	public function testVbscriptHrefIsStripped() {
+		$this->assertStringNotContainsString(
+			'vbscript',
+			$this->sanitize( '<a href="vbscript:msgbox(1)">click</a>' )
+		);
+	}
+
+	public function testEventHandlerAndOtherAttributesAreStripped() {
+		$html = $this->sanitize(
+			'<a href="https://example.org" onclick="steal()" class="x" style="color:red" target="_blank">L</a>'
+		);
+
+		$this->assertStringContainsString( 'href="https://example.org"', $html );
+		$this->assertStringNotContainsString( 'onclick', $html );
+		$this->assertStringNotContainsString( 'class', $html );
+		$this->assertStringNotContainsString( 'style', $html );
+		$this->assertStringNotContainsString( 'target', $html );
+	}
+
+	public function testNestedDisallowedTagsBecomeText() {
+		$html = $this->sanitize( '<a href="https://example.org"><b>bold</b> plain</a>' );
+
+		$this->assertStringContainsString( 'href="https://example.org"', $html );
+		$this->assertStringContainsString( 'bold plain', $html );
+		$this->assertStringNotContainsString( '<b>', $html );
+	}
+
+	public function testEachAnchorIsSanitizedWhenThereAreMultiple() {
+		$html = $this->sanitize(
+			'<a href="https://safe.example">Safe</a><a href="javascript:evil()">Evil</a>'
+		);
+
+		$this->assertStringContainsString( 'href="https://safe.example"', $html );
+		$this->assertStringContainsString( 'Safe', $html );
+		$this->assertStringContainsString( 'Evil', $html );
+		$this->assertStringNotContainsString( 'javascript', $html );
+	}
+
+	public function testProtocolRelativeHrefIsStripped() {
+		$this->assertStringNotContainsString(
+			'href',
+			$this->sanitize( '<a href="//evil.example/x">link</a>' )
+		);
+	}
+
+}

--- a/tests/Unit/CombiningLeafletConfigLookupTest.php
+++ b/tests/Unit/CombiningLeafletConfigLookupTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\Unit;
+
+use Maps\CombiningLeafletConfigLookup;
+use Maps\Tests\TestDoubles\StubLeafletConfigSource;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Maps\CombiningLeafletConfigLookup
+ */
+class CombiningLeafletConfigLookupTest extends TestCase {
+
+	private function phpConfig( array $overrides = [] ): array {
+		return array_merge(
+			[
+				'layerDefinitions' => [],
+				'defaultLayers' => [ 'OpenStreetMap' ],
+				'defaultOverlays' => [],
+				'availableLayers' => [ 'OpenStreetMap' => true ],
+				'availableOverlays' => [ 'OpenSeaMap' => true ],
+			],
+			$overrides
+		);
+	}
+
+	private function newLookup( array $phpConfig, ?array $wikiConfig, bool $enabled = true ): CombiningLeafletConfigLookup {
+		return new CombiningLeafletConfigLookup(
+			$phpConfig,
+			new StubLeafletConfigSource( $wikiConfig ),
+			$enabled
+		);
+	}
+
+	public function testUsesPhpConfigWhenThereIsNoWikiConfig() {
+		$config = $this->newLookup(
+			$this->phpConfig( [ 'defaultLayers' => [ 'OpenTopoMap' ] ] ),
+			null
+		)->getConfig();
+
+		$this->assertSame( [ 'OpenTopoMap' ], $config->getDefaultLayers() );
+	}
+
+	public function testWikiLayerDefinitionsAreMergedWithPhpDefinitions() {
+		$config = $this->newLookup(
+			$this->phpConfig( [
+				'layerDefinitions' => [ 'Php' => [ 'url' => 'https://tiles.example/php/{z}/{x}/{y}.png' ] ],
+			] ),
+			[ 'layerDefinitions' => [ 'Wiki' => [ 'url' => 'https://tiles.example/wiki/{z}/{x}/{y}.png' ] ] ]
+		)->getConfig();
+
+		$names = $config->getLayerDefinitions()->getLayerNames();
+
+		$this->assertContains( 'Php', $names );
+		$this->assertContains( 'Wiki', $names );
+	}
+
+	public function testWikiLayerDefinitionWinsOnNameCollision() {
+		$config = $this->newLookup(
+			$this->phpConfig( [
+				'layerDefinitions' => [ 'Shared' => [ 'url' => 'https://tiles.example/php/{z}/{x}/{y}.png' ] ],
+			] ),
+			[ 'layerDefinitions' => [ 'Shared' => [ 'url' => 'https://tiles.example/wiki/{z}/{x}/{y}.png' ] ] ]
+		)->getConfig();
+
+		$this->assertSame(
+			'https://tiles.example/wiki/{z}/{x}/{y}.png',
+			$config->getLayerDefinitions()->getDefinitions( [ 'Shared' ] )['Shared']['url']
+		);
+	}
+
+	public function testAvailableLayersAreMergedPerNameWithWikiWinning() {
+		$config = $this->newLookup(
+			$this->phpConfig( [ 'availableLayers' => [ 'Kept' => true, 'Disabled' => true ] ] ),
+			[ 'availableLayers' => [ 'Disabled' => false, 'Added' => true ] ]
+		)->getConfig();
+
+		$available = $config->getAvailableLayers();
+
+		$this->assertTrue( $available['Kept'] );
+		$this->assertFalse( $available['Disabled'] );
+		$this->assertTrue( $available['Added'] );
+	}
+
+	public function testWikiDefaultLayersReplacePhpDefaultLayers() {
+		$config = $this->newLookup(
+			$this->phpConfig( [ 'defaultLayers' => [ 'OpenStreetMap' ] ] ),
+			[ 'defaultLayers' => [ 'OpenTopoMap', 'Esri.WorldImagery' ] ]
+		)->getConfig();
+
+		$this->assertSame( [ 'OpenTopoMap', 'Esri.WorldImagery' ], $config->getDefaultLayers() );
+	}
+
+	public function testPhpDefaultLayersAreKeptWhenWikiConfigOmitsThem() {
+		$config = $this->newLookup(
+			$this->phpConfig( [ 'defaultLayers' => [ 'OpenStreetMap' ] ] ),
+			[ 'layerDefinitions' => [] ]
+		)->getConfig();
+
+		$this->assertSame( [ 'OpenStreetMap' ], $config->getDefaultLayers() );
+	}
+
+	public function testInvalidWikiDefaultLayersFallBackToPhp() {
+		$config = $this->newLookup(
+			$this->phpConfig( [ 'defaultLayers' => [ 'OpenStreetMap' ] ] ),
+			[ 'defaultLayers' => 'not-a-list' ]
+		)->getConfig();
+
+		$this->assertSame( [ 'OpenStreetMap' ], $config->getDefaultLayers() );
+	}
+
+	public function testWikiConfigIsIgnoredWhenDisabled() {
+		$config = $this->newLookup(
+			$this->phpConfig( [ 'defaultLayers' => [ 'OpenStreetMap' ] ] ),
+			[ 'defaultLayers' => [ 'OpenTopoMap' ] ],
+			false
+		)->getConfig();
+
+		$this->assertSame( [ 'OpenStreetMap' ], $config->getDefaultLayers() );
+	}
+
+	public function testNumericWikiLayerNameIsPreserved() {
+		$config = $this->newLookup(
+			$this->phpConfig(),
+			[ 'layerDefinitions' => [ '1904' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ] ] ]
+		)->getConfig();
+
+		$this->assertArrayHasKey(
+			'1904',
+			$config->getLayerDefinitions()->getDefinitions( [ '1904' ] )
+		);
+	}
+
+	public function testConfigIsMemoized() {
+		$lookup = $this->newLookup( $this->phpConfig(), null );
+
+		$this->assertSame( $lookup->getConfig(), $lookup->getConfig() );
+	}
+
+}

--- a/tests/Unit/CombiningLeafletConfigLookupTest.php
+++ b/tests/Unit/CombiningLeafletConfigLookupTest.php
@@ -111,6 +111,15 @@ class CombiningLeafletConfigLookupTest extends TestCase {
 		$this->assertSame( [ 'OpenStreetMap' ], $config->getDefaultLayers() );
 	}
 
+	public function testEmptyWikiDefaultLayersClearThePhpDefaults() {
+		$config = $this->newLookup(
+			$this->phpConfig( [ 'defaultLayers' => [ 'OpenStreetMap' ] ] ),
+			[ 'defaultLayers' => [] ]
+		)->getConfig();
+
+		$this->assertSame( [], $config->getDefaultLayers() );
+	}
+
 	public function testWikiConfigIsIgnoredWhenDisabled() {
 		$config = $this->newLookup(
 			$this->phpConfig( [ 'defaultLayers' => [ 'OpenStreetMap' ] ] ),

--- a/tests/Unit/DataAccess/WikiLeafletConfigSourceTest.php
+++ b/tests/Unit/DataAccess/WikiLeafletConfigSourceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\Unit\DataAccess;
+
+use Maps\DataAccess\WikiLeafletConfigSource;
+use Maps\Tests\TestDoubles\StubPageContentFetcher;
+use MediaWiki\Content\Content;
+use MediaWiki\Content\JsonContent;
+use MediaWiki\Content\WikitextContent;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Maps\DataAccess\WikiLeafletConfigSource
+ */
+class WikiLeafletConfigSourceTest extends TestCase {
+
+	private function sourceFor( ?Content $content ): WikiLeafletConfigSource {
+		return new WikiLeafletConfigSource( new StubPageContentFetcher( $content ), 'Maps' );
+	}
+
+	public function testReturnsLeafletSectionFromJsonContent() {
+		$source = $this->sourceFor( new JsonContent( '{ "leaflet": { "defaultLayers": [ "OpenStreetMap" ] } }' ) );
+
+		$this->assertSame( [ 'defaultLayers' => [ 'OpenStreetMap' ] ], $source->getLeafletConfig() );
+	}
+
+	public function testReturnsNullWhenThereIsNoPage() {
+		$this->assertNull( $this->sourceFor( null )->getLeafletConfig() );
+	}
+
+	public function testReturnsNullForNonJsonContent() {
+		$this->assertNull( $this->sourceFor( new WikitextContent( '{ "leaflet": {} }' ) )->getLeafletConfig() );
+	}
+
+	public function testReturnsNullWhenThereIsNoLeafletSection() {
+		$this->assertNull( $this->sourceFor( new JsonContent( '{ "other": 1 }' ) )->getLeafletConfig() );
+	}
+
+	public function testReturnsNullForInvalidJson() {
+		$this->assertNull( $this->sourceFor( new JsonContent( 'not json' ) )->getLeafletConfig() );
+	}
+
+	public function testReturnsNullWhenLeafletSectionIsNotAnObject() {
+		$this->assertNull( $this->sourceFor( new JsonContent( '{ "leaflet": "nope" }' ) )->getLeafletConfig() );
+	}
+
+	public function testReturnsNullWhenTheContentFetcherThrows() {
+		$source = new WikiLeafletConfigSource(
+			new class( null ) extends StubPageContentFetcher {
+				public function getPageContent( string $pageTitle, int $defaultNamespace = NS_MAIN ): ?Content {
+					throw new \RuntimeException( 'Database unavailable' );
+				}
+			},
+			'Maps'
+		);
+
+		$this->assertNull( $source->getLeafletConfig() );
+	}
+
+}

--- a/tests/Unit/LeafletConfigValidatorTest.php
+++ b/tests/Unit/LeafletConfigValidatorTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\Unit;
+
+use Maps\LeafletConfigValidator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Maps\LeafletConfigValidator
+ */
+class LeafletConfigValidatorTest extends TestCase {
+
+	private function validate( string $json ): array {
+		return ( new LeafletConfigValidator() )->validate( $json );
+	}
+
+	private function configWithDefinition( string $definitionJson ): string {
+		return '{"leaflet":{"layerDefinitions":{"Historic":' . $definitionJson . '}}}';
+	}
+
+	public function testEmptyObjectIsValid() {
+		$this->assertSame( [], $this->validate( '{}' ) );
+	}
+
+	public function testEmptyLeafletSectionIsValid() {
+		$this->assertSame( [], $this->validate( '{"leaflet":{}}' ) );
+	}
+
+	public function testFullyPopulatedConfigIsValid() {
+		$json = '{
+			"leaflet": {
+				"layerDefinitions": {
+					"Historic 1904": {
+						"url": "https://tiles.example/{z}/{x}/{y}.png",
+						"options": { "attribution": "Historic", "maxZoom": 18 }
+					},
+					"Weather": {
+						"wms": true,
+						"url": "https://example.org/wms",
+						"options": { "layers": "precip", "format": "image/png", "transparent": true }
+					}
+				},
+				"defaultLayers": [ "OpenStreetMap" ],
+				"defaultOverlays": [],
+				"availableLayers": { "OpenStreetMap": true, "Esri.WorldImagery": false },
+				"availableOverlays": { "OpenSeaMap": true }
+			}
+		}';
+
+		$this->assertSame( [], $this->validate( $json ) );
+	}
+
+	public function testSyntaxErrorIsLeftToCore() {
+		$this->assertSame( [], $this->validate( '{ not valid json' ) );
+	}
+
+	public function testLiteralNullIsRejected() {
+		$this->assertSame( [ [ LeafletConfigValidator::ERROR_INVALID_JSON ] ], $this->validate( 'null' ) );
+	}
+
+	public function testNonObjectJsonIsRejected() {
+		$this->assertSame( [ [ LeafletConfigValidator::ERROR_INVALID_JSON ] ], $this->validate( '123' ) );
+	}
+
+	public function testJsonArrayIsRejected() {
+		$this->assertSame( [ [ LeafletConfigValidator::ERROR_INVALID_JSON ] ], $this->validate( '[ 1, 2 ]' ) );
+	}
+
+	public function testUnknownTopLevelKeyIsRejected() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_UNKNOWN_KEY, 'somethingElse' ] ],
+			$this->validate( '{ "somethingElse": 1 }' )
+		);
+	}
+
+	public function testLeafletMustBeAnObject() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_NOT_OBJECT, 'leaflet' ] ],
+			$this->validate( '{ "leaflet": [ 1, 2 ] }' )
+		);
+	}
+
+	public function testUnknownLeafletKeyIsRejected() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_UNKNOWN_KEY, 'zoom' ] ],
+			$this->validate( '{ "leaflet": { "zoom": 5 } }' )
+		);
+	}
+
+	public function testLayerDefinitionsMustBeAnObject() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_NOT_OBJECT, 'layerDefinitions' ] ],
+			$this->validate( '{ "leaflet": { "layerDefinitions": [ 1 ] } }' )
+		);
+	}
+
+	public function testReservedLayerNameIsRejected() {
+		$json = '{"leaflet":{"layerDefinitions":{'
+			. '"Good1":{"url":"https://tiles.example/1/{z}/{x}/{y}.png"},'
+			. '"__proto__":{"url":"https://tiles.example/2/{z}/{x}/{y}.png"},'
+			. '"Good2":{"url":"https://tiles.example/3/{z}/{x}/{y}.png"}'
+			. '}}}';
+
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_INVALID_LAYER_NAME, '__proto__' ] ],
+			$this->validate( $json )
+		);
+	}
+
+	public function testLayerDefinitionMustBeAnObject() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_NOT_OBJECT, 'Historic' ] ],
+			$this->validate( $this->configWithDefinition( '"not-an-object"' ) )
+		);
+	}
+
+	public function testUnknownDefinitionKeyIsRejected() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_UNKNOWN_LAYER_KEY, 'Historic', 'colour' ] ],
+			$this->validate( $this->configWithDefinition(
+				'{ "url": "https://tiles.example/{z}/{x}/{y}.png", "colour": "red" }'
+			) )
+		);
+	}
+
+	public function testMissingUrlIsRejected() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_INVALID_URL, 'Historic' ] ],
+			$this->validate( $this->configWithDefinition( '{ "options": {} }' ) )
+		);
+	}
+
+	public function testNonHttpUrlIsRejected() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_INVALID_URL, 'Historic' ] ],
+			$this->validate( $this->configWithDefinition( '{ "url": "ftp://tiles.example/{z}/{x}/{y}.png" }' ) )
+		);
+	}
+
+	public function testNonBooleanWmsIsRejected() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_INVALID_WMS, 'Historic' ] ],
+			$this->validate( $this->configWithDefinition(
+				'{ "url": "https://tiles.example/{z}/{x}/{y}.png", "wms": "yes" }'
+			) )
+		);
+	}
+
+	public function testUnknownOptionIsRejected() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_UNKNOWN_OPTION, 'Historic', 'evil' ] ],
+			$this->validate( $this->configWithDefinition(
+				'{ "url": "https://tiles.example/{z}/{x}/{y}.png", "options": { "maxZoom": 18, "evil": 1, "opacity": 0.5 } }'
+			) )
+		);
+	}
+
+	public function testWmsOnlyOptionIsRejectedForTileLayer() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_UNKNOWN_OPTION, 'Historic', 'layers' ] ],
+			$this->validate( $this->configWithDefinition(
+				'{ "url": "https://tiles.example/{z}/{x}/{y}.png", "options": { "layers": "x" } }'
+			) )
+		);
+	}
+
+	public function testWmsOptionIsAcceptedForWmsLayer() {
+		$this->assertSame(
+			[],
+			$this->validate( $this->configWithDefinition(
+				'{ "url": "https://example.org/wms", "wms": true, "options": { "layers": "x" } }'
+			) )
+		);
+	}
+
+	public function testNonStringAttributionIsRejected() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_INVALID_ATTRIBUTION, 'Historic' ] ],
+			$this->validate( $this->configWithDefinition(
+				'{ "url": "https://tiles.example/{z}/{x}/{y}.png", "options": { "attribution": 5 } }'
+			) )
+		);
+	}
+
+	public function testAttributionMarkupIsAcceptedAtSaveTime() {
+		$this->assertSame(
+			[],
+			$this->validate( $this->configWithDefinition(
+				'{ "url": "https://tiles.example/{z}/{x}/{y}.png", "options": { "attribution": "<script>x</script>" } }'
+			) )
+		);
+	}
+
+	public function testNonHttpErrorTileUrlOptionIsRejected() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_INVALID_OPTION_URL, 'Historic', 'errorTileUrl' ] ],
+			$this->validate( $this->configWithDefinition(
+				'{ "url": "https://tiles.example/{z}/{x}/{y}.png", "options": { "errorTileUrl": "javascript:alert(1)" } }'
+			) )
+		);
+	}
+
+	public function testOptionsMustBeAnObject() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_NOT_OBJECT, 'Historic.options' ] ],
+			$this->validate( $this->configWithDefinition(
+				'{ "url": "https://tiles.example/{z}/{x}/{y}.png", "options": [ 1 ] }'
+			) )
+		);
+	}
+
+	public function testInvalidDefaultLayersIsRejected() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_INVALID_DEFAULT_LIST, 'defaultLayers' ] ],
+			$this->validate( '{ "leaflet": { "defaultLayers": "OpenStreetMap" } }' )
+		);
+	}
+
+	public function testDefaultLayersWithNonStringElementIsRejected() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_INVALID_DEFAULT_LIST, 'defaultLayers' ] ],
+			$this->validate( '{ "leaflet": { "defaultLayers": [ "OpenStreetMap", 5 ] } }' )
+		);
+	}
+
+	public function testInvalidAvailableLayersIsRejected() {
+		$this->assertSame(
+			[ [ LeafletConfigValidator::ERROR_INVALID_AVAILABILITY, 'availableLayers' ] ],
+			$this->validate( '{ "leaflet": { "availableLayers": { "OpenStreetMap": "yes" } } }' )
+		);
+	}
+
+	public function testValidAvailabilityAndDefaultsAreAccepted() {
+		$this->assertSame(
+			[],
+			$this->validate(
+				'{ "leaflet": { "defaultLayers": [ "OpenStreetMap" ], "availableLayers": { "OpenStreetMap": true, "Esri": false } } }'
+			)
+		);
+	}
+
+	public function testAllErrorsAreReported() {
+		$json = '{"leaflet":{"layerDefinitions":{"Historic":{"url":"ftp://x"}},"defaultLayers":"x"}}';
+
+		$this->assertEqualsCanonicalizing(
+			[
+				[ LeafletConfigValidator::ERROR_INVALID_URL, 'Historic' ],
+				[ LeafletConfigValidator::ERROR_INVALID_DEFAULT_LIST, 'defaultLayers' ],
+			],
+			$this->validate( $json )
+		);
+	}
+
+}

--- a/tests/Unit/LeafletLayerDefinitionsTest.php
+++ b/tests/Unit/LeafletLayerDefinitionsTest.php
@@ -142,4 +142,130 @@ class LeafletLayerDefinitionsTest extends TestCase {
 		$this->assertSame( [], $definitions->getDefinitions( [ 'Unknown' ] ) );
 	}
 
+	public function testAttributionHtmlIsSanitized() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Historic' => [
+				'url' => 'https://tiles.example/{z}/{x}/{y}.png',
+				'options' => [
+					'attribution' => '<a href="https://osm.org">OSM</a><script>alert(1)</script>',
+				],
+			],
+		] );
+
+		$attribution = $definitions->getDefinitions( [ 'Historic' ] )['Historic']['options']['attribution'];
+
+		$this->assertStringContainsString( 'href="https://osm.org"', $attribution );
+		$this->assertStringNotContainsString( '<script', $attribution );
+	}
+
+	public function testUnknownOptionIsDropped() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Historic' => [
+				'url' => 'https://tiles.example/{z}/{x}/{y}.png',
+				'options' => [ 'maxZoom' => 18, 'evilOption' => 'x' ],
+			],
+		] );
+
+		$this->assertSame(
+			[ 'maxZoom' => 18 ],
+			$definitions->getDefinitions( [ 'Historic' ] )['Historic']['options']
+		);
+	}
+
+	public function testWmsOnlyOptionIsDroppedFromTileLayer() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Tile' => [
+				'url' => 'https://tiles.example/{z}/{x}/{y}.png',
+				'options' => [ 'layers' => 'weather', 'maxZoom' => 18 ],
+			],
+		] );
+
+		$this->assertSame(
+			[ 'maxZoom' => 18 ],
+			$definitions->getDefinitions( [ 'Tile' ] )['Tile']['options']
+		);
+	}
+
+	public function testDefinitionWithNonHttpUrlIsSkipped() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Ftp' => [ 'url' => 'ftp://tiles.example/{z}/{x}/{y}.png' ],
+		] );
+
+		$this->assertSame( [], $definitions->getLayerNames() );
+	}
+
+	public function testDefinitionWithProtocolRelativeUrlIsSkipped() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Rel' => [ 'url' => '//tiles.example/{z}/{x}/{y}.png' ],
+		] );
+
+		$this->assertSame( [], $definitions->getLayerNames() );
+	}
+
+	public function testInvalidErrorTileUrlOptionIsDropped() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Historic' => [
+				'url' => 'https://tiles.example/{z}/{x}/{y}.png',
+				'options' => [ 'errorTileUrl' => 'javascript:alert(1)' ],
+			],
+		] );
+
+		$this->assertSame(
+			[],
+			$definitions->getDefinitions( [ 'Historic' ] )['Historic']['options']
+		);
+	}
+
+	public function testValidErrorTileUrlOptionIsKept() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Historic' => [
+				'url' => 'https://tiles.example/{z}/{x}/{y}.png',
+				'options' => [ 'errorTileUrl' => 'https://tiles.example/error.png' ],
+			],
+		] );
+
+		$this->assertSame(
+			[ 'errorTileUrl' => 'https://tiles.example/error.png' ],
+			$definitions->getDefinitions( [ 'Historic' ] )['Historic']['options']
+		);
+	}
+
+	public function testReservedLayerNameIsSkipped() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Before' => [ 'url' => 'https://tiles.example/b/{z}/{x}/{y}.png' ],
+			'__proto__' => [ 'url' => 'https://tiles.example/p/{z}/{x}/{y}.png' ],
+			'After' => [ 'url' => 'https://tiles.example/a/{z}/{x}/{y}.png' ],
+		] );
+
+		$this->assertSame( [ 'Before', 'After' ], $definitions->getLayerNames() );
+	}
+
+	public function testTooLongLayerNameIsSkipped() {
+		$definitions = new LeafletLayerDefinitions( [
+			str_repeat( 'a', 201 ) => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ],
+		] );
+
+		$this->assertSame( [], $definitions->getLayerNames() );
+	}
+
+	public function testNumericLayerNameIsKept() {
+		$definitions = new LeafletLayerDefinitions( [
+			'1904' => [ 'url' => 'https://tiles.example/{z}/{x}/{y}.png' ],
+		] );
+
+		$this->assertSame( [ '1904' ], $definitions->getLayerNames() );
+		$this->assertArrayHasKey( '1904', $definitions->getDefinitions( [ '1904' ] ) );
+	}
+
+	public function testUrlTemplateTokensArePreserved() {
+		$definitions = new LeafletLayerDefinitions( [
+			'Tokens' => [ 'url' => 'https://{s}.tiles.example/{z}/{x}/{y}.png' ],
+		] );
+
+		$this->assertSame(
+			'https://{s}.tiles.example/{z}/{x}/{y}.png',
+			$definitions->getDefinitions( [ 'Tokens' ] )['Tokens']['url']
+		);
+	}
+
 }

--- a/tests/Unit/LeafletServiceTest.php
+++ b/tests/Unit/LeafletServiceTest.php
@@ -4,9 +4,11 @@ declare( strict_types = 1 );
 
 namespace Maps\Tests\Unit;
 
+use Maps\LeafletConfig;
 use Maps\LeafletLayerDefinitions;
 use Maps\LeafletService;
 use Maps\Map\MapData;
+use Maps\Tests\TestDoubles\FixedLeafletConfigLookup;
 use Maps\Tests\TestDoubles\ImageValueObject;
 use Maps\Tests\TestDoubles\InMemoryImageRepository;
 use PHPUnit\Framework\TestCase;
@@ -16,27 +18,6 @@ use ReflectionMethod;
  * @covers \Maps\LeafletService
  */
 class LeafletServiceTest extends TestCase {
-
-	private array $originalGlobals = [];
-
-	protected function setUp(): void {
-		parent::setUp();
-
-		$this->originalGlobals = [
-			'egMapsLeafletAvailableLayers' => $GLOBALS['egMapsLeafletAvailableLayers'] ?? null,
-			'egMapsLeafletAvailableOverlayLayers' => $GLOBALS['egMapsLeafletAvailableOverlayLayers'] ?? null,
-		];
-
-		$GLOBALS['egMapsLeafletAvailableLayers'] = [ 'OpenStreetMap' => true, 'OpenTopoMap' => true ];
-		$GLOBALS['egMapsLeafletAvailableOverlayLayers'] = [ 'OpenSeaMap' => true, 'OpenRailwayMap' => true ];
-	}
-
-	protected function tearDown(): void {
-		$GLOBALS['egMapsLeafletAvailableLayers'] = $this->originalGlobals['egMapsLeafletAvailableLayers'];
-		$GLOBALS['egMapsLeafletAvailableOverlayLayers'] = $this->originalGlobals['egMapsLeafletAvailableOverlayLayers'];
-
-		parent::tearDown();
-	}
 
 	public function testZeroWidthImageLayerIsSkipped() {
 		$imageRepo = new InMemoryImageRepository();
@@ -240,7 +221,15 @@ class LeafletServiceTest extends TestCase {
 	): LeafletService {
 		return new LeafletService(
 			$imageRepo,
-			$layerDefinitions ?? new LeafletLayerDefinitions( [] )
+			new FixedLeafletConfigLookup(
+				new LeafletConfig(
+					$layerDefinitions ?? new LeafletLayerDefinitions( [] ),
+					[ 'OpenStreetMap' ],
+					[],
+					[ 'OpenStreetMap' => true, 'OpenTopoMap' => true ],
+					[ 'OpenSeaMap' => true, 'OpenRailwayMap' => true ]
+				)
+			)
 		);
 	}
 

--- a/tests/Unit/Map/CargoFormat/CargoOutputBuilderTest.php
+++ b/tests/Unit/Map/CargoFormat/CargoOutputBuilderTest.php
@@ -7,10 +7,12 @@ namespace Maps\Tests\Unit\Map\CargoFormat;
 use DataValues\Geo\Values\LatLongValue;
 use Maps\Map\CargoFormat\CargoOutputBuilder;
 use Maps\Map\Marker;
+use Maps\LeafletConfig;
 use Maps\LeafletLayerDefinitions;
 use Maps\LeafletService;
 use Maps\Map\MapOutputBuilder;
 use Maps\MappingServices;
+use Maps\Tests\TestDoubles\FixedLeafletConfigLookup;
 use Maps\Tests\TestDoubles\ImageValueObject;
 use Maps\Tests\TestDoubles\InMemoryImageRepository;
 use ParamProcessor\ParamDefinitionFactory;
@@ -53,7 +55,10 @@ class CargoOutputBuilderTest extends TestCase {
 	}
 
 	private function callSetIconUrl( InMemoryImageRepository $imageRepo, array $markers, string $iconParameter ): void {
-		$leafletService = new LeafletService( new InMemoryImageRepository(), new LeafletLayerDefinitions( [] ) );
+		$leafletService = new LeafletService(
+			new InMemoryImageRepository(),
+			new FixedLeafletConfigLookup( new LeafletConfig( new LeafletLayerDefinitions( [] ), [], [], [], [] ) )
+		);
 
 		$builder = new CargoOutputBuilder(
 			new MapOutputBuilder(),


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/Maps/issues/924

Adds a MediaWiki:Maps JSON config page for the Leaflet layer settings, combined with
LocalSettings.php with the wiki page winning. Core enforces the editinterface and
editsitejson rights via a forced JSON content model (ContentHandlerDefaultModelFor), and
edits are validated on save (EditFilter) with precise, i18n'd errors. The page is read
lazily at parse time and falls back to the PHP config when it is missing, invalid or the
database is unavailable. A new $egMapsEnableInWikiConfig (default true) disables it.

Exposed settings: custom layerDefinitions plus the default and available base layers and
overlays. The singular $egMapsLeafletLayer is intentionally omitted as it is unused.

The layer-definition contract is hardened for both the PHP and wiki sources through one
pipeline (breaking change, hence 14.0.0): url and errorTileUrl must be http(s), only
allowlisted Leaflet options are kept, and attribution is sanitized server-side to plain
text and http(s) links. Save-time validation is hand-rolled to give precise per-field
errors without adding a dependency.

> <sub>AI-authored — Claude Code, `Opus 4.8 (max)`; detailed brief from a Fable session (relaying @JeroenDeDauw), no human revisions; diff not yet human-reviewed but AI self-reviewed with findings addressed; full PHPUnit suite green locally (370 tests) with the new tests mutation-verified, and CI green.</sub>

<details><summary>Production notes</summary>

Design and the implementation brief by `Fable 5 (max)`; implemented end to end by `Opus 4.8 (max)` in a separate session. Full scope delivered (config-page infrastructure plus the default/availability settings). Save-time validation is hand-rolled rather than opis/json-schema to yield precise per-field messages without adding a runtime dependency. A read-only AI review empirically fuzzed the attribution sanitizer against ~65 XSS vectors (no bypass found) and confirmed no config read happens during extension setup.

</details>
