### PR TITLE
Support several GeoJSON sources in one Leaflet map

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,8 @@ different releases and which versions of PHP and MediaWiki they support, see the
 Not yet released
 
 * The Leaflet `geojson` parameter now takes a semicolon-separated list of pages or URLs, shown together on one map. Existing values containing a semicolon are split into several sources. (#831)
+* Fixed the GeoJSON editor being offered for a source outside the `GeoJson` namespace, where saving wrote to a different page
+* Fixed a source whose content is JSON but not an object stopping the page it is shown on from rendering at all
 
 ## Maps 14.0.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,7 +7,7 @@ different releases and which versions of PHP and MediaWiki they support, see the
 
 Not yet released
 
-* The Leaflet `geojson` parameter now takes several semicolon-separated pages or URLs, shown together on one map. A single page name or URL that itself contains a semicolon is split into several sources. (#831)
+* The Leaflet `geojson` parameter now takes a semicolon-separated list of pages or URLs, shown together on one map. Existing values containing a semicolon are split into several sources. (#831)
 
 ## Maps 14.0.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,7 +7,7 @@ different releases and which versions of PHP and MediaWiki they support, see the
 
 Not yet released
 
-* The Leaflet `geojson` parameter now takes several semicolon-separated pages or URLs, shown together on one map (#831)
+* The Leaflet `geojson` parameter now takes several semicolon-separated pages or URLs, shown together on one map. A single page name or URL that itself contains a semicolon is split into several sources. (#831)
 
 ## Maps 14.0.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,12 @@ different releases and which versions of PHP and MediaWiki they support, see the
 [platform compatibility tables](INSTALL.md#platform-compatibility-and-release-status).
 
 
+## Maps 14.1.0
+
+Not yet released
+
+* The Leaflet `geojson` parameter now takes several semicolon-separated pages or URLs, shown together on one map (#831)
+
 ## Maps 14.0.0
 
 Released on July 21st, 2026.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -78,7 +78,7 @@
 	"maps-displaymap-par-rectangles": "Rectangles to display",
 	"maps-displaymap-par-static": "Make the map static",
 	"maps-displaymap-par-wmsoverlay": "Use a WMS overlay",
-	"maps-displaymap-par-geojson": "One or more pages or file URLs containing GeoJSON data, separated by semicolons",
+	"maps-displaymap-par-geojson": "One or more pages or URLs containing GeoJSON data, separated by semicolons",
 	"maps-fullscreen-button": "Toggle fullscreen",
 	"maps-fullscreen-button-tooltip": "View the map as fullscreen or embedded.",
 	"maps-mylocation-button-tooltip": "Show my location on the map.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -78,7 +78,7 @@
 	"maps-displaymap-par-rectangles": "Rectangles to display",
 	"maps-displaymap-par-static": "Make the map static",
 	"maps-displaymap-par-wmsoverlay": "Use a WMS overlay",
-	"maps-displaymap-par-geojson": "URL of a file or name of the page containing GeoJSON data",
+	"maps-displaymap-par-geojson": "One or more pages or file URLs containing GeoJSON data, separated by semicolons",
 	"maps-fullscreen-button": "Toggle fullscreen",
 	"maps-fullscreen-button-tooltip": "View the map as fullscreen or embedded.",
 	"maps-mylocation-button-tooltip": "Show my location on the map.",

--- a/resources/leaflet/FeatureBuilder.js
+++ b/resources/leaflet/FeatureBuilder.js
@@ -213,7 +213,7 @@
 			markers.addLayer(createMarker(properties, options));
 		});
 
-		if (options.geojson !== '') {
+		if (options.geojson.length > 0) {
 			features.addLayer(newGeoJsonLayer(options, markers));
 		}
 

--- a/resources/leaflet/jquery.leaflet.js
+++ b/resources/leaflet/jquery.leaflet.js
@@ -87,7 +87,7 @@
 		};
 
 		this.shouldShowEditButton = function() {
-			if ( options.geojson === '' || options.GeoJsonSource === null ) {
+			if ( !options.GeoJsonSource ) {
 				return false;
 			}
 
@@ -127,7 +127,7 @@
 			maps.api.getLatestRevision('GeoJson:' + options.GeoJsonSource).done(
 				function(revision) {
 					if (revision.revid === options.GeoJsonRevisionId) {
-						_this.initializeEditor(options.geojson);
+						_this.initializeEditor(options.geojson[0]);
 					}
 					else {
 						_this.purgePage();
@@ -145,7 +145,8 @@
 				_this.purgePage();
 
 				editor.remove();
-				options.geojson = editor.getLayer().toGeoJSON();
+				// Kept as a list of sources, which is what the map data holds and what rendering expects
+				options.geojson = [ editor.getLayer().toGeoJSON() ];
 				_this.mapContent = maps.leaflet.FeatureBuilder.contentLayerFromOptions(options).addTo(_this.map);
 
 				alert(mw.msg('maps-json-editor-changes-saved'));

--- a/resources/leaflet/jquery.leaflet.js
+++ b/resources/leaflet/jquery.leaflet.js
@@ -43,8 +43,19 @@
 		return mapOptions;
 	}
 
+	// Map data from before the geojson parameter became a list holds a single GeoJSON object, and
+	// still reaches this code from the parser cache after an upgrade.
+	function geoJsonSources(geoJson) {
+		if (Array.isArray(geoJson)) {
+			return geoJson;
+		}
+
+		return geoJson ? [geoJson] : [];
+	}
+
 	$.fn.leafletmaps = function ( options ) {
 		let _this = this;
+		options.geojson = geoJsonSources(options.geojson);
 		_this.options = options; // needed by LeafletAjax.js
 
 		this.setup = function() {
@@ -145,7 +156,7 @@
 				_this.purgePage();
 
 				editor.remove();
-				// Kept as a list of sources, which is what the map data holds and what rendering expects
+				// Replacing the whole list is safe because the editor only runs with a single source
 				options.geojson = [ editor.getLayer().toGeoJSON() ];
 				_this.mapContent = maps.leaflet.FeatureBuilder.contentLayerFromOptions(options).addTo(_this.map);
 

--- a/src/DataAccess/GeoJsonFetcher.php
+++ b/src/DataAccess/GeoJsonFetcher.php
@@ -91,7 +91,8 @@ class GeoJsonFetcher {
 
 		$json = json_decode( $jsonString, true );
 
-		if ( $json === null ) {
+		// Not just null: JSON that is a bare number, string or boolean decodes to a non-array.
+		if ( !is_array( $json ) ) {
 			return [];
 		}
 

--- a/src/DataAccess/GeoJsonSources.php
+++ b/src/DataAccess/GeoJsonSources.php
@@ -1,0 +1,65 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\DataAccess;
+
+/**
+ * The GeoJSON of a single map, gathered from the one or more sources given via the geojson parameter.
+ */
+class GeoJsonSources {
+
+	/**
+	 * @var GeoJsonFetcherResult[]
+	 */
+	private array $results;
+
+	/**
+	 * @param GeoJsonFetcherResult[] $results One result per given source, including sources that could not be fetched.
+	 */
+	public function __construct( array $results ) {
+		$this->results = array_values( $results );
+	}
+
+	/**
+	 * The content of the sources that could be fetched. L.geoJSON() takes this list as is.
+	 *
+	 * @return array[]
+	 */
+	public function getContents(): array {
+		return array_values(
+			array_filter(
+				array_map(
+					static fn ( GeoJsonFetcherResult $result ): array => $result->getContent(),
+					$this->results
+				),
+				static fn ( array $content ): bool => $content !== []
+			)
+		);
+	}
+
+	/**
+	 * The GeoJson page the visual editor may write to, or null when there is none.
+	 *
+	 * The editor saves the whole map layer to this page, so a map showing several sources must not have
+	 * one: saving would replace a single page with the combined content of all of them. Which sources
+	 * could be fetched deliberately plays no role, so that creating or deleting an unrelated page does
+	 * not make the editor appear or disappear.
+	 */
+	public function getEditablePageName(): ?string {
+		return $this->getEditableResult()?->getTitleValue()?->getText();
+	}
+
+	public function getEditableRevisionId(): ?int {
+		return $this->getEditableResult()?->getRevisionId();
+	}
+
+	private function getEditableResult(): ?GeoJsonFetcherResult {
+		if ( count( $this->results ) !== 1 ) {
+			return null;
+		}
+
+		return $this->results[0]->getTitleValue() === null ? null : $this->results[0];
+	}
+
+}

--- a/src/DataAccess/GeoJsonSources.php
+++ b/src/DataAccess/GeoJsonSources.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace Maps\DataAccess;
 
 /**
- * The GeoJSON of a single map, gathered from the one or more sources given via the geojson parameter.
+ * The GeoJSON of a single map, gathered from the sources given via the geojson parameter.
  */
 class GeoJsonSources {
 
@@ -41,10 +41,10 @@ class GeoJsonSources {
 	/**
 	 * The GeoJson page the visual editor may write to, or null when there is none.
 	 *
-	 * The editor saves the whole map layer to this page, so a map showing several sources must not have
-	 * one: saving would replace a single page with the combined content of all of them. Which sources
-	 * could be fetched deliberately plays no role, so that creating or deleting an unrelated page does
-	 * not make the editor appear or disappear.
+	 * The editor replaces the whole page with the layer it was opened on, so a map showing more than one
+	 * source must not have an editable page: the save would overwrite it with just one of the sources.
+	 * Whether the sources could be fetched deliberately plays no role in the count, so a source becoming
+	 * reachable or unreachable cannot turn the editor on for a map that shows several.
 	 */
 	public function getEditablePageName(): ?string {
 		return $this->getEditableResult()?->getTitleValue()?->getText();
@@ -55,11 +55,19 @@ class GeoJsonSources {
 	}
 
 	private function getEditableResult(): ?GeoJsonFetcherResult {
-		if ( count( $this->results ) !== 1 ) {
-			return null;
+		if ( count( $this->results ) === 1 && $this->isGeoJsonPage( $this->results[0] ) ) {
+			return $this->results[0];
 		}
 
-		return $this->results[0]->getTitleValue() === null ? null : $this->results[0];
+		return null;
+	}
+
+	/**
+	 * The editor saves to `GeoJson:` plus this name, so a page in any other namespace, which the fetcher
+	 * also accepts as long as its content is JSON, must not be editable.
+	 */
+	private function isGeoJsonPage( GeoJsonFetcherResult $result ): bool {
+		return $result->getTitleValue()?->getNamespace() === NS_GEO_JSON;
 	}
 
 }

--- a/src/LeafletService.php
+++ b/src/LeafletService.php
@@ -5,6 +5,8 @@ declare( strict_types = 1 );
 namespace Maps;
 
 use Maps\Config\EffectiveSettings;
+use Maps\DataAccess\GeoJsonFetcherResult;
+use Maps\DataAccess\GeoJsonSources;
 use Maps\DataAccess\ImageRepository;
 use Maps\Map\MapData;
 use ParamProcessor\ParameterTypes;
@@ -159,7 +161,10 @@ class LeafletService implements MappingService {
 
 		$params['geojson'] = [
 			'type' => ParameterTypes::STRING,
-			'default' => '',
+			'islist' => true,
+			// Not the default comma: commas are common in both GeoJson page titles and URLs.
+			'delimiter' => ';',
+			'default' => [],
 			'message' => 'maps-displaymap-par-geojson',
 		];
 
@@ -222,7 +227,7 @@ class LeafletService implements MappingService {
 			$modules[] = 'ext.maps.leaflet.fullscreen';
 		}
 
-		if ( $params['geojson'] !== '' ) {
+		if ( ( $params['GeoJsonSource'] ?? null ) !== null ) {
 			$modules[] = 'ext.maps.leaflet.editor';
 		}
 
@@ -275,14 +280,12 @@ class LeafletService implements MappingService {
 	}
 
 	public function newMapDataFromParameters( array $params ): MapData {
-		if ( $params['geojson'] !== '' ) {
-			$fetcher = MapsFactory::globalInstance()->newGeoJsonFetcher();
+		if ( $params['geojson'] !== [] ) {
+			$sources = $this->fetchGeoJson( $params['geojson'] );
 
-			$result = $fetcher->fetch( $params['geojson'] );
-
-			$params['geojson'] = $result->getContent();
-			$params['GeoJsonSource'] = $result->getTitleValue() === null ? null : $result->getTitleValue()->getText();
-			$params['GeoJsonRevisionId'] = $result->getRevisionId();
+			$params['geojson'] = $sources->getContents();
+			$params['GeoJsonSource'] = $sources->getEditablePageName();
+			$params['GeoJsonRevisionId'] = $sources->getEditableRevisionId();
 		}
 
 		$params['imageLayers'] = $this->getJsImageLayers( $params['image layers'] );
@@ -299,6 +302,20 @@ class LeafletService implements MappingService {
 		$params = $this->addUsedLayerDefinitions( $params );
 
 		return new MapData( $params );
+	}
+
+	/**
+	 * @param string[] $sourceNames Page names in the GeoJson namespace or URLs
+	 */
+	private function fetchGeoJson( array $sourceNames ): GeoJsonSources {
+		$fetcher = MapsFactory::globalInstance()->newGeoJsonFetcher();
+
+		return new GeoJsonSources(
+			array_map(
+				static fn ( string $sourceName ): GeoJsonFetcherResult => $fetcher->fetch( $sourceName ),
+				array_filter( $sourceNames, static fn ( string $sourceName ): bool => $sourceName !== '' )
+			)
+		);
 	}
 
 	/**

--- a/src/LeafletService.php
+++ b/src/LeafletService.php
@@ -227,7 +227,7 @@ class LeafletService implements MappingService {
 			$modules[] = 'ext.maps.leaflet.fullscreen';
 		}
 
-		if ( ( $params['GeoJsonSource'] ?? null ) !== null ) {
+		if ( isset( $params['GeoJsonSource'] ) ) {
 			$modules[] = 'ext.maps.leaflet.editor';
 		}
 

--- a/tests/Integration/DataAccess/GeoJsonFetcherTest.php
+++ b/tests/Integration/DataAccess/GeoJsonFetcherTest.php
@@ -73,6 +73,15 @@ class GeoJsonFetcherTest extends TestCase {
 		);
 	}
 
+	public function testWhenFileContainsJsonThatIsNotAnObject_emptyJsonIsReturned() {
+		$this->fileFetcher = new StubFileFetcher( '42' );
+
+		$this->assertSame(
+			[],
+			$this->newJsonFileParser()->parse( 'http://example.com/file' )
+		);
+	}
+
 	public function testWhenFileIsEmpty_emptyJsonIsReturned() {
 		$this->fileFetcher = new NullFileFetcher();
 

--- a/tests/Integration/Parser/LeafletTest.php
+++ b/tests/Integration/Parser/LeafletTest.php
@@ -220,4 +220,13 @@ class LeafletTest extends TestCase {
 		);
 	}
 
+	public function testLeadingDelimiterLeavesTheSingleSourceEditable() {
+		$this->createGeoJsonPage( 'FirstSource', self::FIRST_FEATURE );
+
+		$this->assertStringContainsData(
+			'"GeoJsonSource":"FirstSource"',
+			$this->parse( '{{#leaflet:geojson=;FirstSource}}' )
+		);
+	}
+
 }

--- a/tests/Integration/Parser/LeafletTest.php
+++ b/tests/Integration/Parser/LeafletTest.php
@@ -6,14 +6,19 @@ namespace Maps\Tests\Integration\Parser;
 
 use Maps\Config\ConfigSchema;
 use Maps\Config\EffectiveSettings;
+use Maps\GeoJsonPages\GeoJsonContent;
 use Maps\LeafletService;
 use Maps\Tests\MapsTestFactory;
 use Maps\Tests\TestDoubles\ImageValueObject;
 use Maps\Tests\TestDoubles\InMemoryImageRepository;
 use Maps\Tests\TestDoubles\StubWikiConfigSource;
+use Maps\Tests\Util\PageCreator;
 use Maps\Tests\Util\TestFactory;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Maps\LeafletService
+ */
 class LeafletTest extends TestCase {
 
 	private array $originalLayerDefinitions;
@@ -132,6 +137,70 @@ class LeafletTest extends TestCase {
 		$html = $this->parse( '{{#leaflet:}}' );
 
 		$this->assertStringNotContainsString( 'layerDefinitions', $html );
+	}
+
+	private function createGeoJsonPage( string $pageName, string $featureTitle ): void {
+		PageCreator::instance()->createPageWithContent(
+			'GeoJson:' . $pageName,
+			new GeoJsonContent( json_encode( [
+				'type' => 'FeatureCollection',
+				'features' => [
+					[
+						'type' => 'Feature',
+						'geometry' => [ 'type' => 'Point', 'coordinates' => [ 4.35, 50.85 ] ],
+						'properties' => [ 'title' => $featureTitle ],
+					],
+				],
+			] ) )
+		);
+	}
+
+	public function testBothGeoJsonSourcesAreRendered() {
+		$this->createGeoJsonPage( 'FirstSource', 'Feature of the first page' );
+		$this->createGeoJsonPage( 'SecondSource', 'Feature of the second page' );
+
+		$html = $this->parse( '{{#leaflet:geojson=FirstSource;SecondSource}}' );
+
+		$this->assertStringContainsData( 'Feature of the first page', $html );
+		$this->assertStringContainsData( 'Feature of the second page', $html );
+	}
+
+	public function testWhitespaceAfterTheDelimiterIsIgnored() {
+		$this->createGeoJsonPage( 'FirstSource', 'Feature of the first page' );
+		$this->createGeoJsonPage( 'SecondSource', 'Feature of the second page' );
+
+		$html = $this->parse( '{{#leaflet:geojson=FirstSource; SecondSource}}' );
+
+		$this->assertStringContainsData( 'Feature of the first page', $html );
+		$this->assertStringContainsData( 'Feature of the second page', $html );
+	}
+
+	public function testMissingSourceDoesNotStopTheRemainingOneFromRendering() {
+		$this->createGeoJsonPage( 'SecondSource', 'Feature of the second page' );
+
+		$html = $this->parse( '{{#leaflet:geojson=NoSuchPage;SecondSource}}' );
+
+		$this->assertStringContainsData( '"geojson":[{"type":"FeatureCollection"', $html );
+		$this->assertStringContainsData( 'Feature of the second page', $html );
+	}
+
+	public function testGeoJsonSourceIsNullWithMultipleSources() {
+		$this->createGeoJsonPage( 'FirstSource', 'Feature of the first page' );
+		$this->createGeoJsonPage( 'SecondSource', 'Feature of the second page' );
+
+		$this->assertStringContainsData(
+			'"GeoJsonSource":null',
+			$this->parse( '{{#leaflet:geojson=FirstSource;SecondSource}}' )
+		);
+	}
+
+	public function testGeoJsonSourceIsThePageNameWithASingleSource() {
+		$this->createGeoJsonPage( 'FirstSource', 'Feature of the first page' );
+
+		$this->assertStringContainsData(
+			'"GeoJsonSource":"FirstSource"',
+			$this->parse( '{{#leaflet:geojson=FirstSource}}' )
+		);
 	}
 
 }

--- a/tests/Integration/Parser/LeafletTest.php
+++ b/tests/Integration/Parser/LeafletTest.php
@@ -21,6 +21,9 @@ use PHPUnit\Framework\TestCase;
  */
 class LeafletTest extends TestCase {
 
+	private const FIRST_FEATURE = 'Feature of the first page';
+	private const SECOND_FEATURE = 'Feature of the second page';
+
 	private array $originalLayerDefinitions;
 
 	protected function setUp(): void {
@@ -155,38 +158,43 @@ class LeafletTest extends TestCase {
 		);
 	}
 
+	private function createTwoGeoJsonPages(): void {
+		$this->createGeoJsonPage( 'FirstSource', self::FIRST_FEATURE );
+		$this->createGeoJsonPage( 'SecondSource', self::SECOND_FEATURE );
+	}
+
+	private function assertBothFeaturesAreRendered( string $html ): void {
+		$this->assertStringContainsData( self::FIRST_FEATURE, $html );
+		$this->assertStringContainsData( self::SECOND_FEATURE, $html );
+	}
+
 	public function testBothGeoJsonSourcesAreRendered() {
-		$this->createGeoJsonPage( 'FirstSource', 'Feature of the first page' );
-		$this->createGeoJsonPage( 'SecondSource', 'Feature of the second page' );
+		$this->createTwoGeoJsonPages();
 
-		$html = $this->parse( '{{#leaflet:geojson=FirstSource;SecondSource}}' );
-
-		$this->assertStringContainsData( 'Feature of the first page', $html );
-		$this->assertStringContainsData( 'Feature of the second page', $html );
+		$this->assertBothFeaturesAreRendered(
+			$this->parse( '{{#leaflet:geojson=FirstSource;SecondSource}}' )
+		);
 	}
 
 	public function testWhitespaceAfterTheDelimiterIsIgnored() {
-		$this->createGeoJsonPage( 'FirstSource', 'Feature of the first page' );
-		$this->createGeoJsonPage( 'SecondSource', 'Feature of the second page' );
+		$this->createTwoGeoJsonPages();
 
-		$html = $this->parse( '{{#leaflet:geojson=FirstSource; SecondSource}}' );
-
-		$this->assertStringContainsData( 'Feature of the first page', $html );
-		$this->assertStringContainsData( 'Feature of the second page', $html );
+		$this->assertBothFeaturesAreRendered(
+			$this->parse( '{{#leaflet:geojson=FirstSource; SecondSource}}' )
+		);
 	}
 
 	public function testMissingSourceDoesNotStopTheRemainingOneFromRendering() {
-		$this->createGeoJsonPage( 'SecondSource', 'Feature of the second page' );
+		$this->createGeoJsonPage( 'SecondSource', self::SECOND_FEATURE );
 
 		$html = $this->parse( '{{#leaflet:geojson=NoSuchPage;SecondSource}}' );
 
 		$this->assertStringContainsData( '"geojson":[{"type":"FeatureCollection"', $html );
-		$this->assertStringContainsData( 'Feature of the second page', $html );
+		$this->assertStringContainsData( self::SECOND_FEATURE, $html );
 	}
 
 	public function testGeoJsonSourceIsNullWithMultipleSources() {
-		$this->createGeoJsonPage( 'FirstSource', 'Feature of the first page' );
-		$this->createGeoJsonPage( 'SecondSource', 'Feature of the second page' );
+		$this->createTwoGeoJsonPages();
 
 		$this->assertStringContainsData(
 			'"GeoJsonSource":null',
@@ -195,11 +203,20 @@ class LeafletTest extends TestCase {
 	}
 
 	public function testGeoJsonSourceIsThePageNameWithASingleSource() {
-		$this->createGeoJsonPage( 'FirstSource', 'Feature of the first page' );
+		$this->createGeoJsonPage( 'FirstSource', self::FIRST_FEATURE );
 
 		$this->assertStringContainsData(
 			'"GeoJsonSource":"FirstSource"',
 			$this->parse( '{{#leaflet:geojson=FirstSource}}' )
+		);
+	}
+
+	public function testTrailingDelimiterLeavesTheSingleSourceEditable() {
+		$this->createGeoJsonPage( 'FirstSource', self::FIRST_FEATURE );
+
+		$this->assertStringContainsData(
+			'"GeoJsonSource":"FirstSource"',
+			$this->parse( '{{#leaflet:geojson=FirstSource;}}' )
 		);
 	}
 

--- a/tests/System/SemanticQueryTest.php
+++ b/tests/System/SemanticQueryTest.php
@@ -60,7 +60,7 @@ class SemanticQueryTest extends TestCase {
 		$this->assertStringContainsString( '<div id="map_leaflet_', $content );
 		$this->assertStringContainsString( '"GeoJsonSource":"TestGeoJson"', $content );
 		$this->assertStringContainsString( '"GeoJsonRevisionId":', $content );
-		$this->assertStringContainsString( '"geojson":{"type":"FeatureCollection"', $content );
+		$this->assertStringContainsString( '"geojson":[{"type":"FeatureCollection"', $content );
 	}
 
 	public function testGoogleMapsQueryContainsImageOverlayData() {

--- a/tests/Unit/DataAccess/GeoJsonSourcesTest.php
+++ b/tests/Unit/DataAccess/GeoJsonSourcesTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\Unit\DataAccess;
+
+use Maps\DataAccess\GeoJsonFetcherResult;
+use Maps\DataAccess\GeoJsonSources;
+use MediaWiki\Title\TitleValue;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Maps\DataAccess\GeoJsonSources
+ */
+class GeoJsonSourcesTest extends TestCase {
+
+	private const REVISION_ID = 42;
+
+	public function testContentOfEverySourceIsIncluded() {
+		$sources = new GeoJsonSources( [
+			$this->newPageResult( 'First', 'FirstFeature' ),
+			$this->newPageResult( 'Second', 'SecondFeature' ),
+		] );
+
+		$this->assertSame(
+			[
+				$this->newFeatureCollection( 'FirstFeature' ),
+				$this->newFeatureCollection( 'SecondFeature' ),
+			],
+			$sources->getContents()
+		);
+	}
+
+	public function testSourcesWithoutContentAreDropped() {
+		$sources = new GeoJsonSources( [
+			$this->newEmptyResult(),
+			$this->newPageResult( 'Second', 'SecondFeature' ),
+			$this->newEmptyResult(),
+		] );
+
+		$this->assertSame(
+			[ $this->newFeatureCollection( 'SecondFeature' ) ],
+			$sources->getContents()
+		);
+	}
+
+	public function testWithoutSourcesThereIsNoContent() {
+		$this->assertSame( [], ( new GeoJsonSources( [] ) )->getContents() );
+	}
+
+	public function testSinglePageSourceIsEditable() {
+		$sources = new GeoJsonSources( [ $this->newPageResult( 'OnlySource', 'Feature' ) ] );
+
+		$this->assertSame( 'OnlySource', $sources->getEditablePageName() );
+		$this->assertSame( self::REVISION_ID, $sources->getEditableRevisionId() );
+	}
+
+	public function testSeveralPageSourcesAreNotEditable() {
+		$sources = new GeoJsonSources( [
+			$this->newPageResult( 'First', 'FirstFeature' ),
+			$this->newPageResult( 'Second', 'SecondFeature' ),
+		] );
+
+		$this->assertNull( $sources->getEditablePageName() );
+		$this->assertNull( $sources->getEditableRevisionId() );
+	}
+
+	public function testSourceThatIsNotAPageIsNotEditable() {
+		$sources = new GeoJsonSources( [ $this->newUrlResult( 'Feature' ) ] );
+
+		$this->assertNull( $sources->getEditablePageName() );
+		$this->assertNull( $sources->getEditableRevisionId() );
+	}
+
+	public function testSecondSourceWithoutContentStillMakesTheFirstOneUneditable() {
+		$sources = new GeoJsonSources( [
+			$this->newPageResult( 'First', 'FirstFeature' ),
+			$this->newEmptyResult(),
+		] );
+
+		$this->assertNull( $sources->getEditablePageName() );
+		$this->assertNull( $sources->getEditableRevisionId() );
+	}
+
+	private function newPageResult( string $pageName, string $featureTitle ): GeoJsonFetcherResult {
+		return new GeoJsonFetcherResult(
+			$this->newFeatureCollection( $featureTitle ),
+			self::REVISION_ID,
+			new TitleValue( NS_GEO_JSON, $pageName )
+		);
+	}
+
+	private function newUrlResult( string $featureTitle ): GeoJsonFetcherResult {
+		return new GeoJsonFetcherResult( $this->newFeatureCollection( $featureTitle ), null, null );
+	}
+
+	private function newEmptyResult(): GeoJsonFetcherResult {
+		return new GeoJsonFetcherResult( [], null, null );
+	}
+
+	private function newFeatureCollection( string $featureTitle ): array {
+		return [
+			'type' => 'FeatureCollection',
+			'features' => [
+				[
+					'type' => 'Feature',
+					'geometry' => [ 'type' => 'Point', 'coordinates' => [ 4.35, 50.85 ] ],
+					'properties' => [ 'title' => $featureTitle ],
+				],
+			],
+		];
+	}
+
+}

--- a/tests/Unit/DataAccess/GeoJsonSourcesTest.php
+++ b/tests/Unit/DataAccess/GeoJsonSourcesTest.php
@@ -72,6 +72,19 @@ class GeoJsonSourcesTest extends TestCase {
 		$this->assertNull( $sources->getEditableRevisionId() );
 	}
 
+	public function testSourceOutsideTheGeoJsonNamespaceIsNotEditable() {
+		$sources = new GeoJsonSources( [
+			new GeoJsonFetcherResult(
+				$this->newFeatureCollection( 'Feature' ),
+				self::REVISION_ID,
+				new TitleValue( NS_MEDIAWIKI, 'Maps' )
+			),
+		] );
+
+		$this->assertNull( $sources->getEditablePageName() );
+		$this->assertNull( $sources->getEditableRevisionId() );
+	}
+
 	public function testSecondSourceWithoutContentStillMakesTheFirstOneUneditable() {
 		$sources = new GeoJsonSources( [
 			$this->newPageResult( 'First', 'FirstFeature' ),

--- a/tests/Unit/LeafletServiceTest.php
+++ b/tests/Unit/LeafletServiceTest.php
@@ -197,7 +197,7 @@ class LeafletServiceTest extends TestCase {
 	private function newLeafletMapData( array $overrides, array $layerDefinitions = [] ): MapData {
 		$params = array_merge(
 			[
-				'geojson' => '',
+				'geojson' => [],
 				'image layers' => [],
 				'layers' => [],
 				'overlays' => [],

--- a/tests/Unit/LeafletServiceTest.php
+++ b/tests/Unit/LeafletServiceTest.php
@@ -190,6 +190,44 @@ class LeafletServiceTest extends TestCase {
 		);
 	}
 
+	public function testEditorModuleIsLoadedForAnEditableGeoJsonSource() {
+		$this->assertContains(
+			'ext.maps.leaflet.editor',
+			$this->resourceModulesFor( [ 'GeoJsonSource' => 'MySource' ] )
+		);
+	}
+
+	public function testEditorModuleIsNotLoadedWhenThereIsNoEditableGeoJsonSource() {
+		$this->assertNotContains(
+			'ext.maps.leaflet.editor',
+			$this->resourceModulesFor( [ 'GeoJsonSource' => null ] )
+		);
+	}
+
+	public function testEditorModuleIsNotLoadedWhenNoGeoJsonIsUsed() {
+		$this->assertNotContains(
+			'ext.maps.leaflet.editor',
+			$this->resourceModulesFor( [] )
+		);
+	}
+
+	/**
+	 * @param array<string, mixed> $overrides
+	 * @return string[]
+	 */
+	private function resourceModulesFor( array $overrides ): array {
+		return $this->newService( new InMemoryImageRepository() )->getResourceModules(
+			array_merge(
+				[
+					'resizable' => false,
+					'cluster' => false,
+					'fullscreen' => false,
+				],
+				$overrides
+			)
+		);
+	}
+
 	/**
 	 * @param array<string, mixed> $overrides
 	 * @param array<string, array> $layerDefinitions

--- a/tests/js/leaflet/FeatureBuilderTest.js
+++ b/tests/js/leaflet/FeatureBuilderTest.js
@@ -1,9 +1,47 @@
-( function () {
+( function ( $ ) {
 	'use strict';
 
 	var FeatureBuilder = window.maps.leaflet.FeatureBuilder;
 
 	QUnit.module( 'Maps.FeatureBuilder' );
+
+	function newOptions( overrides ) {
+		return $.extend( {
+			lines: [],
+			polygons: [],
+			circles: [],
+			rectangles: [],
+			locations: [],
+			geojson: [],
+			cluster: false,
+			copycoords: false
+		}, overrides || {} );
+	}
+
+	function newPointFeature( title ) {
+		return {
+			type: 'Feature',
+			geometry: { type: 'Point', coordinates: [ 5, 52 ] },
+			properties: { title: title }
+		};
+	}
+
+	function newFeatureCollection( features ) {
+		return { type: 'FeatureCollection', features: features };
+	}
+
+	// The number of features rendered by the GeoJSON layer of a map content layer, 0 when there is none.
+	function geoJsonFeatureCount( contentLayer ) {
+		var count = 0;
+
+		contentLayer.eachLayer( function ( layer ) {
+			if ( layer instanceof L.GeoJSON ) {
+				count = layer.getLayers().length;
+			}
+		} );
+
+		return count;
+	}
 
 	QUnit.test( 'createMarker returns a marker at the correct position', function ( assert ) {
 		var marker = FeatureBuilder.createMarker(
@@ -37,19 +75,12 @@
 	} );
 
 	QUnit.test( 'contentLayerFromOptions returns feature group with markers', function ( assert ) {
-		var featureGroup = FeatureBuilder.contentLayerFromOptions( {
-			lines: [],
-			polygons: [],
-			circles: [],
-			rectangles: [],
+		var featureGroup = FeatureBuilder.contentLayerFromOptions( newOptions( {
 			locations: [
 				{ lat: 52, lon: 5, title: 'Amsterdam', text: '', icon: '' },
 				{ lat: 51.9, lon: 4.5, title: 'Rotterdam', text: '', icon: '' }
-			],
-			geojson: '',
-			cluster: false,
-			copycoords: false
-		} );
+			]
+		} ) );
 
 		assert.true( featureGroup instanceof L.FeatureGroup, 'Returns an L.FeatureGroup' );
 		assert.true( featureGroup.markerLayer !== undefined, 'Feature group has a markerLayer property' );
@@ -57,41 +88,35 @@
 	} );
 
 	QUnit.test( 'contentLayerFromOptions with GeoJSON Points includes points in GeoJSON layer', function ( assert ) {
-		var featureGroup = FeatureBuilder.contentLayerFromOptions( {
-			lines: [],
-			polygons: [],
-			circles: [],
-			rectangles: [],
-			locations: [],
-			cluster: false,
-			copycoords: false,
-			geojson: {
-				type: 'FeatureCollection',
-				features: [
-					{
-						type: 'Feature',
-						geometry: { type: 'Point', coordinates: [ 5, 52 ] },
-						properties: { title: 'Amsterdam' }
-					},
-					{
-						type: 'Feature',
-						geometry: { type: 'Point', coordinates: [ 4.5, 51.9 ] },
-						properties: { title: 'Rotterdam' }
-					}
-				]
-			}
-		} );
+		var featureGroup = FeatureBuilder.contentLayerFromOptions( newOptions( {
+			geojson: [
+				newFeatureCollection( [ newPointFeature( 'Amsterdam' ), newPointFeature( 'Rotterdam' ) ] )
+			]
+		} ) );
 
-		// Find the L.GeoJSON layer within the feature group
-		var geoJsonLayer = null;
-		featureGroup.eachLayer( function ( layer ) {
-			if ( layer instanceof L.GeoJSON ) {
-				geoJsonLayer = layer;
-			}
-		} );
-
-		assert.notStrictEqual( geoJsonLayer, null, 'GeoJSON layer exists in feature group' );
-		assert.strictEqual( geoJsonLayer.getLayers().length, 2, 'GeoJSON layer contains 2 sublayers for Point features' );
+		assert.strictEqual( geoJsonFeatureCount( featureGroup ), 2, 'GeoJSON layer contains both Point features' );
 	} );
 
-}() );
+	QUnit.test( 'contentLayerFromOptions includes the features of every GeoJSON source', function ( assert ) {
+		var featureGroup = FeatureBuilder.contentLayerFromOptions( newOptions( {
+			geojson: [
+				newFeatureCollection( [ newPointFeature( 'Amsterdam' ), newPointFeature( 'Rotterdam' ) ] ),
+				newFeatureCollection( [ newPointFeature( 'Ghent' ) ] )
+			]
+		} ) );
+
+		assert.strictEqual( geoJsonFeatureCount( featureGroup ), 3, 'GeoJSON layer contains the features of both sources' );
+	} );
+
+	QUnit.test( 'contentLayerFromOptions adds no GeoJSON layer without sources', function ( assert ) {
+		var featureGroup = FeatureBuilder.contentLayerFromOptions( newOptions() );
+
+		var hasGeoJsonLayer = false;
+		featureGroup.eachLayer( function ( layer ) {
+			hasGeoJsonLayer = hasGeoJsonLayer || layer instanceof L.GeoJSON;
+		} );
+
+		assert.false( hasGeoJsonLayer, 'Feature group has no GeoJSON layer' );
+	} );
+
+}( window.jQuery ) );

--- a/tests/js/leaflet/FeatureBuilderTest.js
+++ b/tests/js/leaflet/FeatureBuilderTest.js
@@ -30,17 +30,17 @@
 		return { type: 'FeatureCollection', features: features };
 	}
 
-	// The number of features rendered by the GeoJSON layer of a map content layer, 0 when there is none.
-	function geoJsonFeatureCount( contentLayer ) {
-		var count = 0;
+	// The GeoJSON layer of a map content layer, or null when there is none.
+	function geoJsonLayerIn( contentLayer ) {
+		var geoJsonLayer = null;
 
 		contentLayer.eachLayer( function ( layer ) {
 			if ( layer instanceof L.GeoJSON ) {
-				count = layer.getLayers().length;
+				geoJsonLayer = layer;
 			}
 		} );
 
-		return count;
+		return geoJsonLayer;
 	}
 
 	QUnit.test( 'createMarker returns a marker at the correct position', function ( assert ) {
@@ -94,7 +94,11 @@
 			]
 		} ) );
 
-		assert.strictEqual( geoJsonFeatureCount( featureGroup ), 2, 'GeoJSON layer contains both Point features' );
+		assert.strictEqual(
+			geoJsonLayerIn( featureGroup ).getLayers().length,
+			2,
+			'GeoJSON layer contains both Point features'
+		);
 	} );
 
 	QUnit.test( 'contentLayerFromOptions includes the features of every GeoJSON source', function ( assert ) {
@@ -105,18 +109,17 @@
 			]
 		} ) );
 
-		assert.strictEqual( geoJsonFeatureCount( featureGroup ), 3, 'GeoJSON layer contains the features of both sources' );
+		assert.strictEqual(
+			geoJsonLayerIn( featureGroup ).getLayers().length,
+			3,
+			'GeoJSON layer contains the features of both sources'
+		);
 	} );
 
 	QUnit.test( 'contentLayerFromOptions adds no GeoJSON layer without sources', function ( assert ) {
 		var featureGroup = FeatureBuilder.contentLayerFromOptions( newOptions() );
 
-		var hasGeoJsonLayer = false;
-		featureGroup.eachLayer( function ( layer ) {
-			hasGeoJsonLayer = hasGeoJsonLayer || layer instanceof L.GeoJSON;
-		} );
-
-		assert.false( hasGeoJsonLayer, 'Feature group has no GeoJSON layer' );
+		assert.strictEqual( geoJsonLayerIn( featureGroup ), null, 'Feature group has no GeoJSON layer' );
 	} );
 
 }( window.jQuery ) );

--- a/tests/js/leaflet/JQueryLeafletTest.js
+++ b/tests/js/leaflet/JQueryLeafletTest.js
@@ -8,7 +8,7 @@
 			circles: [],
 			rectangles: [],
 			locations: [],
-			geojson: '',
+			geojson: [],
 			cluster: false,
 			copycoords: false,
 			layers: [ 'OpenStreetMap' ],
@@ -78,6 +78,32 @@
 		}
 
 		return captured;
+	}
+
+	function newPointCollection( title ) {
+		return {
+			type: 'FeatureCollection',
+			features: [
+				{
+					type: 'Feature',
+					geometry: { type: 'Point', coordinates: [ 5, 52 ] },
+					properties: { title: title }
+				}
+			]
+		};
+	}
+
+	// The number of features rendered by the GeoJSON layer of a map content layer, 0 when there is none.
+	function geoJsonFeatureCount( contentLayer ) {
+		var count = 0;
+
+		contentLayer.eachLayer( function ( layer ) {
+			if ( layer instanceof L.GeoJSON ) {
+				count = layer.getLayers().length;
+			}
+		} );
+
+		return count;
 	}
 
 	QUnit.test( 'leafletmaps creates a jquery object with map methods', function ( assert ) {
@@ -394,6 +420,70 @@
 		}
 
 		assert.strictEqual( capturedName, 'OpenStreetMap', 'Names without a definition use the provider catalog' );
+	} );
+
+	QUnit.test( 'shouldShowEditButton is false when there is no GeoJsonSource', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var options = makeDefaultOptions();
+		delete options.GeoJsonSource;
+
+		var jqueryMap = createTestMap( $div, options );
+
+		assert.false( jqueryMap.shouldShowEditButton(), 'No edit button without an editable source' );
+
+		jqueryMap.map.remove();
+	} );
+
+	QUnit.test( 'shouldShowEditButton is true for a single GeoJson page source', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var options = makeDefaultOptions( {
+			geojson: [ newPointCollection( 'Amsterdam' ) ],
+			GeoJsonSource: 'TestSource'
+		} );
+
+		var jqueryMap = createTestMap( $div, options );
+
+		assert.true( jqueryMap.shouldShowEditButton(), 'Edit button shown for an editable source' );
+
+		jqueryMap.map.remove();
+	} );
+
+	QUnit.test( 'saving in the editor renders the map content again', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var options = makeDefaultOptions( {
+			geojson: [ newPointCollection( 'Amsterdam' ) ],
+			GeoJsonSource: 'TestSource'
+		} );
+
+		var jqueryMap = createTestMap( $div, options );
+
+		var savedHandler = null;
+		jqueryMap.editor = {
+			initialize: function () {},
+			remove: function () {},
+			onSaved: function ( handler ) {
+				savedHandler = handler;
+			},
+			getLayer: function () {
+				return L.geoJSON( newPointCollection( 'Rotterdam' ) );
+			}
+		};
+		jqueryMap.purgePage = function () {};
+		jqueryMap.addEditButton = function () {};
+
+		var originalAlert = window.alert;
+		window.alert = function () {};
+
+		try {
+			jqueryMap.initializeEditor( options.geojson[ 0 ] );
+			savedHandler();
+		} finally {
+			window.alert = originalAlert;
+		}
+
+		assert.strictEqual( geoJsonFeatureCount( jqueryMap.mapContent ), 1, 'The saved GeoJSON is rendered again' );
+
+		jqueryMap.map.remove();
 	} );
 
 	QUnit.test( 'addOverlays builds a custom overlay from its definition', function ( assert ) {

--- a/tests/js/leaflet/JQueryLeafletTest.js
+++ b/tests/js/leaflet/JQueryLeafletTest.js
@@ -35,7 +35,10 @@
 	QUnit.module( 'Maps.JQueryLeaflet', QUnit.newMwEnvironment( {
 		config: {
 			egMapsLeafletLayersApiKeys: {},
-			egMapsScriptPath: mw.config.get( 'wgExtensionAssetsPath' ) + '/Maps/'
+			egMapsScriptPath: mw.config.get( 'wgExtensionAssetsPath' ) + '/Maps/',
+			// Equal, so the map is not being viewed at an old revision
+			wgCurRevisionId: 100,
+			wgRevisionId: 100
 		}
 	} ) );
 
@@ -434,6 +437,20 @@
 		jqueryMap.map.remove();
 	} );
 
+	QUnit.test( 'shouldShowEditButton is false for several sources', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var options = makeDefaultOptions( {
+			geojson: [ newPointCollection( 'Amsterdam' ), newPointCollection( 'Rotterdam' ) ],
+			GeoJsonSource: null
+		} );
+
+		var jqueryMap = createTestMap( $div, options );
+
+		assert.false( jqueryMap.shouldShowEditButton(), 'No edit button for a map showing several sources' );
+
+		jqueryMap.map.remove();
+	} );
+
 	QUnit.test( 'shouldShowEditButton is true for a single GeoJson page source', function ( assert ) {
 		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
 		var options = makeDefaultOptions( {
@@ -444,6 +461,60 @@
 		var jqueryMap = createTestMap( $div, options );
 
 		assert.true( jqueryMap.shouldShowEditButton(), 'Edit button shown for an editable source' );
+
+		jqueryMap.map.remove();
+	} );
+
+	// Map data cached from before geojson became a list holds a single GeoJSON object.
+	function newLegacyShapedOptions( collection ) {
+		var options = makeDefaultOptions( { GeoJsonSource: 'TestSource', GeoJsonRevisionId: 7 } );
+		options.geojson = collection;
+
+		return options;
+	}
+
+	QUnit.test( 'cached map data holding a single GeoJSON object still renders it', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var options = newLegacyShapedOptions( newPointCollection( 'Amsterdam' ) );
+
+		var jqueryMap = createTestMap( $div, options );
+
+		assert.strictEqual( geoJsonFeatureCount( jqueryMap.mapContent ), 1, 'The cached GeoJSON is rendered' );
+
+		jqueryMap.map.remove();
+	} );
+
+	QUnit.test( 'the editor is opened with the GeoJSON of cached map data holding a single object', function ( assert ) {
+		var $div = $( '<div>' ).css( { width: '400px', height: '300px' } ).appendTo( '#qunit-fixture' );
+		var collection = newPointCollection( 'Amsterdam' );
+		var options = newLegacyShapedOptions( collection );
+
+		var jqueryMap = createTestMap( $div, options );
+
+		var initializedWith = 'not initialized';
+		jqueryMap.editor = {
+			initialize: function ( geoJson ) {
+				initializedWith = geoJson;
+			},
+			remove: function () {},
+			onSaved: function () {},
+			getLayer: function () {
+				return L.geoJSON( collection );
+			}
+		};
+
+		var originalGetLatestRevision = maps.api.getLatestRevision;
+		maps.api.getLatestRevision = function () {
+			return $.Deferred().resolve( { revid: options.GeoJsonRevisionId } ).promise();
+		};
+
+		try {
+			jqueryMap.startEditMode();
+		} finally {
+			maps.api.getLatestRevision = originalGetLatestRevision;
+		}
+
+		assert.deepEqual( initializedWith, collection, 'The editor is seeded with the whole cached GeoJSON' );
 
 		jqueryMap.map.remove();
 	} );


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/Maps/issues/831

`geojson` becomes a list parameter, so `{{#display_map:geojson=A;B}}` and the Leaflet
result format show several GeoJson pages or URLs on one map. Each source is fetched
separately; sources that fail are dropped without affecting the rest.

The delimiter is `;` rather than ParamProcessor's default `,`, since commas are common
inside GeoJson page titles and URLs, and `;` is what the other Maps list parameters use.
An existing value containing a semicolon now splits into several sources, which the
release notes call out.

The visual editor replaces the whole page it was opened on, so `GeoJsonSource` and
`GeoJsonRevisionId` are non-null only when exactly one non-empty value was given and it
resolved to a page in the GeoJson namespace. The count comes from the values given rather
than from which fetches succeeded, so a source becoming reachable or unreachable can never
turn the editor on for a map that shows several. The namespace condition also fixes a
pre-existing bug: the fetcher resolves any page whose content is JSON, so
`geojson=MediaWiki:Maps` used to show an edit button that saved to `GeoJson:Maps`.

Two further failure paths are fixed here: map data still in the parser cache after an
upgrade holds a single GeoJSON object, which the editor would have opened empty over a page
that still had features; and a source whose content is a bare JSON scalar made the fetcher
throw, taking the whole page render down.

Considered and omitted: each source as a separately toggleable overlay in the layer control
(a distinct feature); de-duplicating identical sources; Google Maps, which has no `geojson`
parameter. Left open: a cap on the number of sources. Wikitext could already trigger as many
fetches with one map per source, but `Special:Ask` takes result-format parameters straight
from the request and is not parser-cached, so one anonymous request can now trigger N
server-side fetches instead of one.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; detailed spec from @JeroenDeDauw, no redirections; diff not yet human-reviewed; every new test seen failing first, mutation-tested, reviewed by four independent AI passes whose blocking findings are fixed here, full PHPUnit and QUnit suites plus PHPStan and phpcs run locally, rendered map and editor gating checked in a browser; CI green.</sub>
