### PR TITLE
Add setting controlling whether kml may come from outside the wiki

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -54,6 +54,14 @@ return [
 	'egMapsResizableByDefault' => false,
 	'egMapsRezoomForKML' => false,
 
+	// Boolean. Whether the kml parameter may reference KML outside of this wiki. These documents are
+	// fetched by the browser of everyone viewing the map, so the host they come from learns the IP
+	// address and user agent of each reader, and can change what it serves after the edit was
+	// reviewed. When false, kml values that are not a file on this wiki are dropped, and the
+	// NetworkLink elements inside a KML document may only point at this wiki. Does not apply to
+	// gkml, which Google fetches and renders on its own servers.
+	'egMapsAllowExternalKml' => true,
+
 	// Boolean. Sets if pages with maps should be put in special category
 	'egMapsEnableCategory' => false,
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Settings are grouped by service and topic:
 The available groups and keys correspond to `LocalSettings.php` settings:
 
 * **general**: `mapWidth`, `mapHeight`, `defaultTitle`, `defaultLabel`, `resizableByDefault`,
-  `rezoomForKml`, `pagesWithMapsCategory`, `distanceUnits`, `distanceUnit`, `distanceDecimals`
+  `rezoomForKml`, `allowExternalKml`, `pagesWithMapsCategory`, `distanceUnits`, `distanceUnit`,
+  `distanceDecimals`
 * **coordinates**: `availableNotations`, `notation`, `directional`
 * **geocoding**: `service` (`geonames`, `google` or `nominatim`)
 * **semanticMediaWiki**: `showTitle`, `hideNamespace`, `template`, `coordinateFormat`,

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,13 @@ different releases and which versions of PHP and MediaWiki they support, see the
 [platform compatibility tables](INSTALL.md#platform-compatibility-and-release-status).
 
 
+## Maps 14.2.0
+
+Not yet released
+
+* Added the `$egMapsAllowExternalKml` setting, also available as `general.allowExternalKml` on the `MediaWiki:Maps` page. Set it to `false` to have the Google Maps `kml` parameter accept only files on the wiki, and to stop `NetworkLink` elements inside a KML file from pointing anywhere else. It defaults to `true`, which keeps the existing behaviour of letting an editor have the browser of everyone viewing the map fetch KML from any host.
+* `NetworkLink` elements in KML files are now followed at most three levels deep, so a KML file that links back to itself no longer makes the browser fetch in an endless loop
+
 ## Maps 14.1.1
 
 Released on July 31st, 2026.

--- a/resources/GoogleMaps/geoxml3/README
+++ b/resources/GoogleMaps/geoxml3/README
@@ -15,6 +15,14 @@ code of its own:
 * geoxml3.js: the NetworkLink refresh schedules a call instead of a string for setInterval to evaluate.
 * ProjectedOverlay.js: draw() builds the ground overlay image with the DOM API instead of an HTML string.
 
+A KML document also names further documents for the library to fetch, through NetworkLink and
+styleUrl. Two more places were changed to bound which of those the browser retrieves:
+
+* geoxml3.js: the allowExternalDocuments parser option, false on wikis that do not allow KML from
+  elsewhere, limits every fetch to the origin of the page.
+* geoxml3.js: NetworkLink elements are followed at most geoXML3.maxNetworkLinkDepth levels deep, so a
+  document linking back to itself cannot make the browser fetch forever.
+
 ProjectedOverlay.js additionally exports its constructor on window, because ResourceLoader runs module
 scripts inside a function, where the declaration geoxml3.js looks for never becomes global.
 

--- a/resources/GoogleMaps/geoxml3/geoxml3.js
+++ b/resources/GoogleMaps/geoxml3/geoxml3.js
@@ -93,6 +93,25 @@ if (!String.prototype.trim) {
 geoXML3 = window.geoXML3 || {instances: []};
 
 /**
+ * Local modification (Maps extension): how deeply NetworkLink elements may nest. A NetworkLink can
+ * point at a document that links back to it, and without a limit the reader's browser would follow
+ * such a cycle forever.
+ */
+geoXML3.maxNetworkLinkDepth = 3;
+
+/**
+ * Local modification (Maps extension): whether a url resolves to the origin of the page, which is
+ * the wiki itself. Anything the browser cannot resolve counts as another origin.
+ */
+geoXML3.isSameOrigin = function (url) {
+	try {
+		return new URL(url, document.baseURI).origin === window.location.origin;
+	} catch (e) {
+		return false;
+	}
+};
+
+/**
  * Constructor for the root KML parser object.
  *
  * <p>All top-level objects and functions are declared under a namespace of geoXML3.
@@ -123,6 +142,8 @@ geoXML3.parser = function (options) {
 			parser: this,
 			docSet: docSet || [],
 			remaining: 1,
+			// Local modification (Maps extension): how many NetworkLink hops led to this document.
+			depth: 0,
 			parseOnly: !(parserOptions.afterParse || parserOptions.processStyles)
 		};
 		thisDoc = new Object();
@@ -131,7 +152,21 @@ geoXML3.parser = function (options) {
 		render(geoXML3.xmlParse(kmlString),thisDoc);
 	}
 
-	var parse = function (urls, docSet) {
+	// Local modification (Maps extension): the reader's browser does the fetching, so the wiki
+	// decides whether KML may come from anywhere else. A KML document names documents of its own,
+	// through NetworkLink and styleUrl, so this is applied everywhere the parser takes a url, not
+	// only to the ones that came from the wikitext.
+	var allowedUrl = function (url) {
+		if (parserOptions.allowExternalDocuments || geoXML3.isSameOrigin(url)) {
+			return true;
+		}
+
+		geoXML3.log('Not fetching KML from outside this wiki: ' + url);
+
+		return false;
+	};
+
+	var parse = function (urls, docSet, depth) {
 		// Process one or more KML documents
 		if (!parserName) {
 			parserName = 'geoXML3.instances[' + (geoXML3.instances.push(this) - 1) + ']';
@@ -142,11 +177,15 @@ geoXML3.parser = function (options) {
 			urls = [urls];
 		}
 
+		urls = urls.filter(allowedUrl);
+
 		// Internal values for the set of documents as a whole
 		var internals = {
 			parser: this,
 			docSet: docSet || [],
 			remaining: urls.length,
+			// Local modification (Maps extension): how many NetworkLink hops led to these documents.
+			depth: depth || 0,
 			parseOnly: !(parserOptions.afterParse || parserOptions.processStyles)
 		};
 		var thisDoc, j;
@@ -520,6 +559,7 @@ geoXML3.parser = function (options) {
 				var rUrl = cleanURL( doc.baseDir, url );
 				if (rUrl === doc.baseUrl) continue;  // self
 				if (docsByUrl[rUrl])      continue;  // already loaded
+				if (!allowedUrl(rUrl))    continue;  // Local modification (Maps extension)
 
 				var thisDoc;
 				var j = docSet.indexOfObjWithItem('baseUrl', rUrl);
@@ -896,6 +936,11 @@ geoXML3.parser = function (options) {
 			var docPath = document.location.pathname.split('/');
 			docPath = docPath.splice(0, docPath.length - 1).join('/');
 			var linkNodes = getElementsByTagName(responseXML, 'NetworkLink');
+			// Local modification (Maps extension): stop following NetworkLinks once they have
+			// nested as deeply as allowed, so a cycle cannot make the browser fetch forever.
+			if (doc.internals.depth >= geoXML3.maxNetworkLinkDepth) {
+				linkNodes = [];
+			}
 			for (i = 0; i < linkNodes.length; i++) {
 				node = linkNodes[i];
 
@@ -944,12 +989,14 @@ geoXML3.parser = function (options) {
 					// and the string form of setInterval evaluates it as code. Schedule a call instead,
 					// like the onChange branch below does.
 					setInterval(
-						doc.internals.parser.parse.bind(doc.internals.parser, networkLink.link.href),
+						doc.internals.parser.parse.bind(
+							doc.internals.parser, networkLink.link.href, undefined, doc.internals.depth + 1),
 						1000 * networkLink.link.refreshInterval);
 				} else if (networkLink.link.refreshMode === 'onChange') {
 					if (networkLink.link.viewRefreshMode === 'never') {
 						// Load the link just once
-						doc.internals.parser.parse(networkLink.link.href, doc.internals.docSet);
+						doc.internals.parser.parse(
+							networkLink.link.href, doc.internals.docSet, doc.internals.depth + 1);
 					} else if (networkLink.link.viewRefreshMode === 'onStop') {
 						// Reload when the map view changes
 
@@ -1490,6 +1537,14 @@ geoXML3.parserOptions = function (overrides) {
 		 */
 		this.processStyles       = false,
 		/**#@-*/
+
+		/**
+		 * Local modification (Maps extension): when false, the parser only fetches documents from
+		 * the origin of the page, including the ones NetworkLink elements point at.
+		 * @type Boolean
+		 * @default true
+		 */
+		this.allowExternalDocuments = true,
 
 		this.markerOptions       = {},
 		this.infoWindowOptions   = {},

--- a/resources/GoogleMaps/jquery.googlemap.js
+++ b/resources/GoogleMaps/jquery.googlemap.js
@@ -202,6 +202,7 @@
 					var geoXml = new geoXML3.parser({
 						map:_this.map,
 						zoom:options.kmlrezoom,
+						allowExternalDocuments:options.allowexternalkml !== false,
 						failedParse:function(document){
 							console.log(options.kml);
 							console.log(document);

--- a/src/Config/ConfigSchema.php
+++ b/src/Config/ConfigSchema.php
@@ -76,6 +76,7 @@ class ConfigSchema {
 			self::replace( 'general', 'defaultLabel', 'egMapsDefaultLabel', new StringType() ),
 			self::replace( 'general', 'resizableByDefault', 'egMapsResizableByDefault', new BooleanType() ),
 			self::replace( 'general', 'rezoomForKml', 'egMapsRezoomForKML', new BooleanType() ),
+			self::replace( 'general', 'allowExternalKml', 'egMapsAllowExternalKml', new BooleanType() ),
 			self::replace( 'general', 'pagesWithMapsCategory', 'egMapsEnableCategory', new BooleanType() ),
 			self::replace( 'general', 'distanceUnits', 'egMapsDistanceUnits', new NumberMapType() ),
 			self::replace( 'general', 'distanceUnit', 'egMapsDistanceUnit', new StringType() ),

--- a/src/DataAccess/MediaWikiFileUrlFinder.php
+++ b/src/DataAccess/MediaWikiFileUrlFinder.php
@@ -14,6 +14,10 @@ use MediaWiki\MediaWikiServices;
 class MediaWikiFileUrlFinder implements FileUrlFinder {
 
 	public function getUrlForFileName( string $fileName ): string {
+		return $this->findFileUrl( $fileName ) ?? trim( $fileName );
+	}
+
+	public function findFileUrl( string $fileName ): ?string {
 		$colonPosition = strpos( $fileName, ':' );
 
 		$titleWithoutPrefix = $colonPosition === false ? $fileName : substr( $fileName, $colonPosition + 1 );
@@ -24,6 +28,6 @@ class MediaWikiFileUrlFinder implements FileUrlFinder {
 			return $file->getURL();
 		}
 
-		return trim( $fileName );
+		return null;
 	}
 }

--- a/src/FileUrlFinder.php
+++ b/src/FileUrlFinder.php
@@ -15,4 +15,9 @@ interface FileUrlFinder {
 	 */
 	public function getUrlForFileName( string $fileName ): string;
 
+	/**
+	 * The url of the file page with this name, or null when this wiki has no such file.
+	 */
+	public function findFileUrl( string $fileName ): ?string;
+
 }

--- a/src/GoogleMapsService.php
+++ b/src/GoogleMapsService.php
@@ -37,10 +37,12 @@ class GoogleMapsService implements MappingService {
 	];
 
 	private EffectiveSettings $config;
+	private FileUrlFinder $fileUrlFinder;
 	private $addedDependencies = [];
 
-	public function __construct( EffectiveSettings $config ) {
+	public function __construct( EffectiveSettings $config, FileUrlFinder $fileUrlFinder ) {
 		$this->config = $config;
+		$this->fileUrlFinder = $fileUrlFinder;
 	}
 
 	public function getName(): string {
@@ -214,22 +216,7 @@ class GoogleMapsService implements MappingService {
 			'default' => [],
 			'message' => 'maps-par-kml',
 			'islist' => true,
-			'post-format' => function( array $kmlFileNames ) {
-				return array_values(
-					array_filter(
-						array_map(
-							function( string $fileName ) {
-								return MediaWikiServices::getInstance()->getUrlUtils()->expand(
-									MapsFunctions::getFileUrl( $fileName ) );
-							},
-							$kmlFileNames
-						),
-						function( string $fileName ) {
-							return $fileName !== '';
-						}
-					)
-				);
-			}
+			'post-format' => fn( array $kmlFileNames ) => $this->getKmlUrls( $kmlFileNames ),
 		];
 
 		$params['gkml'] = [
@@ -284,6 +271,42 @@ class GoogleMapsService implements MappingService {
 	 */
 	private function getTypeNames(): array {
 		return array_keys( self::MAP_TYPES );
+	}
+
+	/**
+	 * @param string[] $kmlFileNames
+	 * @return string[]
+	 */
+	private function getKmlUrls( array $kmlFileNames ): array {
+		$urls = [];
+
+		foreach ( $kmlFileNames as $fileName ) {
+			$url = $this->getKmlUrl( $fileName );
+
+			if ( $url !== '' ) {
+				$urls[] = $url;
+			}
+		}
+
+		return $urls;
+	}
+
+	/**
+	 * The url the browser should fetch this kml value from. Empty when there is none: the value is
+	 * blank, or it is not a file on this wiki while the wiki does not allow external KML.
+	 */
+	private function getKmlUrl( string $fileName ): string {
+		$url = $this->fileUrlFinder->findFileUrl( $fileName ) ?? $this->getExternalKmlUrl( $fileName );
+
+		return (string)MediaWikiServices::getInstance()->getUrlUtils()->expand( $url );
+	}
+
+	private function getExternalKmlUrl( string $fileName ): string {
+		return $this->allowsExternalKml() ? trim( $fileName ) : '';
+	}
+
+	private function allowsExternalKml(): bool {
+		return (bool)$this->config->get( 'egMapsAllowExternalKml' );
 	}
 
 	public function newMapId(): string {
@@ -383,6 +406,10 @@ class GoogleMapsService implements MappingService {
 	}
 
 	public function newMapDataFromParameters( array $params ): MapData {
+		// The browser fetches the documents that NetworkLink elements point at, and only sees the
+		// urls once it has the KML in hand, so it needs to know the policy itself.
+		$params['allowexternalkml'] = $this->allowsExternalKml();
+
 		return new MapData( $params );
 	}
 

--- a/src/MapsFactory.php
+++ b/src/MapsFactory.php
@@ -197,7 +197,10 @@ class MapsFactory {
 	}
 
 	private function getGoogleMapsService(): GoogleMapsService {
-		$this->googleService ??= new GoogleMapsService( $this->getEffectiveSettings() );
+		$this->googleService ??= new GoogleMapsService(
+			$this->getEffectiveSettings(),
+			$this->getFileUrlFinder()
+		);
 
 		return $this->googleService;
 	}

--- a/tests/Integration/Config/OnWikiConfigTest.php
+++ b/tests/Integration/Config/OnWikiConfigTest.php
@@ -50,6 +50,15 @@ class OnWikiConfigTest extends TestCase {
 		$this->assertStringContainsString( htmlspecialchars( '"zoom":3' ), $html );
 	}
 
+	public function testWikiExternalKmlPolicyReachesTheRenderedMapData(): void {
+		$html = $this->parseWithWikiConfig(
+			[ 'general' => [ 'allowExternalKml' => false ] ],
+			'{{#google_maps:kml=https://example.com/points.kml}}'
+		);
+
+		$this->assertStringContainsString( htmlspecialchars( '"kml":[]' ), $html );
+	}
+
 	public function testWikiLeafletLayerDefinitionReachesTheRenderedMapData(): void {
 		$html = $this->parseWithWikiConfig(
 			[ 'leaflet' => [ 'layerDefinitions' => [

--- a/tests/Integration/Parser/GoogleMapsTest.php
+++ b/tests/Integration/Parser/GoogleMapsTest.php
@@ -17,12 +17,19 @@ class GoogleMapsTest extends TestCase {
 		return TestFactory::newInstance()->parse( $textToParse );
 	}
 
-	public function testGoogleMapsKmlFiltersInvalidFileNames() {
+	public function testEmptyKmlEntriesAreDropped() {
 		$this->assertStringContainsData(
-			'"kml":["ValidFile.kml"],',
+			'"kml":["https://example.com/points.kml"],',
 			$this->parse(
-				"{{#google_maps:kml=, ,ValidFile.kml ,}}"
+				"{{#google_maps:kml=, ,https://example.com/points.kml ,}}"
 			)
+		);
+	}
+
+	public function testExternalKmlIsAllowedByDefault() {
+		$this->assertStringContainsData(
+			'"allowexternalkml":true',
+			$this->parse( '{{#google_maps:1,1}}' )
 		);
 	}
 

--- a/tests/TestDoubles/InMemoryFileUrlFinder.php
+++ b/tests/TestDoubles/InMemoryFileUrlFinder.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\TestDoubles;
+
+use Maps\FileUrlFinder;
+
+class InMemoryFileUrlFinder implements FileUrlFinder {
+
+	/**
+	 * @var array<string, string>
+	 */
+	private array $urls = [];
+
+	public function addFile( string $fileName, string $url ): void {
+		$this->urls[$fileName] = $url;
+	}
+
+	public function getUrlForFileName( string $fileName ): string {
+		return $this->findFileUrl( $fileName ) ?? trim( $fileName );
+	}
+
+	public function findFileUrl( string $fileName ): ?string {
+		return $this->urls[trim( $fileName )] ?? null;
+	}
+
+}

--- a/tests/Unit/GoogleMapsServiceTest.php
+++ b/tests/Unit/GoogleMapsServiceTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\Unit;
+
+use Maps\Config\ConfigSchema;
+use Maps\Config\EffectiveSettings;
+use Maps\GoogleMapsService;
+use Maps\Tests\TestDoubles\InMemoryFileUrlFinder;
+use Maps\Tests\TestDoubles\StubWikiConfigSource;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Maps\GoogleMapsService
+ */
+class GoogleMapsServiceTest extends TestCase {
+
+	private const WIKI_FILE = 'Points.kml';
+	private const WIKI_FILE_URL = 'https://wiki.example/images/Points.kml';
+	private const EXTERNAL_URL = 'https://example.com/points.kml';
+
+	public function testWikiFileIsResolvedToItsUrl(): void {
+		$this->assertSame(
+			[ self::WIKI_FILE_URL ],
+			$this->kmlUrlsAllowingExternal( [ self::WIKI_FILE ] )
+		);
+	}
+
+	public function testExternalUrlIsUsedAsIs(): void {
+		$this->assertSame(
+			[ self::EXTERNAL_URL ],
+			$this->kmlUrlsAllowingExternal( [ self::EXTERNAL_URL ] )
+		);
+	}
+
+	public function testOnlyWikiFilesRemainWhenExternalKmlIsNotAllowed(): void {
+		$this->assertSame(
+			[ self::WIKI_FILE_URL ],
+			$this->kmlUrlsWithoutExternal( [ self::EXTERNAL_URL, self::WIKI_FILE, 'Missing.kml' ] )
+		);
+	}
+
+	public function testMapDataSaysExternalKmlIsAllowed(): void {
+		$this->assertTrue( $this->externalKmlInMapData( true ) );
+	}
+
+	public function testMapDataSaysExternalKmlIsNotAllowed(): void {
+		$this->assertFalse( $this->externalKmlInMapData( false ) );
+	}
+
+	/**
+	 * @param string[] $fileNames
+	 * @return string[]
+	 */
+	private function kmlUrlsAllowingExternal( array $fileNames ): array {
+		return $this->kmlUrls( $fileNames, true );
+	}
+
+	/**
+	 * @param string[] $fileNames
+	 * @return string[]
+	 */
+	private function kmlUrlsWithoutExternal( array $fileNames ): array {
+		return $this->kmlUrls( $fileNames, false );
+	}
+
+	/**
+	 * The urls the browser is told to fetch for the given values of the kml parameter.
+	 *
+	 * @param string[] $fileNames
+	 * @return string[]
+	 */
+	private function kmlUrls( array $fileNames, bool $allowExternalKml ): array {
+		$postFormat = $this->newService( $allowExternalKml )->getParameterInfo()['kml']['post-format'];
+
+		return $postFormat( $fileNames );
+	}
+
+	private function externalKmlInMapData( bool $allowExternalKml ): bool {
+		return $this->newService( $allowExternalKml )
+			->newMapDataFromParameters( [] )
+			->getParameters()['allowexternalkml'];
+	}
+
+	private function newService( bool $allowExternalKml ): GoogleMapsService {
+		$fileUrlFinder = new InMemoryFileUrlFinder();
+		$fileUrlFinder->addFile( self::WIKI_FILE, self::WIKI_FILE_URL );
+
+		return new GoogleMapsService(
+			$this->newSettings( $allowExternalKml ),
+			$fileUrlFinder
+		);
+	}
+
+	private function newSettings( bool $allowExternalKml ): EffectiveSettings {
+		return new EffectiveSettings(
+			array_merge(
+				require __DIR__ . '/../../DefaultSettings.php',
+				[ 'egMapsAllowExternalKml' => $allowExternalKml ]
+			),
+			ConfigSchema::newDefault(),
+			new StubWikiConfigSource( null ),
+			true
+		);
+	}
+
+}

--- a/tests/js/GoogleMaps/geoxml3/KmlRenderingTest.js
+++ b/tests/js/GoogleMaps/geoxml3/KmlRenderingTest.js
@@ -1,4 +1,4 @@
-( function ( mw ) {
+( function ( $, mw ) {
 	'use strict';
 
 	var originalGoogle = window.google;
@@ -139,6 +139,12 @@
 		);
 	}
 
+	// Without a refresh mode geoxml3 loads the linked document once, right away, rather than
+	// scheduling it.
+	function kmlWithLoadedNetworkLink( href ) {
+		return kmlDocument( '<NetworkLink><Link><href>' + href + '</href></Link></NetworkLink>' );
+	}
+
 	function kmlWithGroundOverlay( iconHref ) {
 		return kmlDocument(
 			'<GroundOverlay><Icon><href>' + iconHref + '</href></Icon>' +
@@ -147,16 +153,21 @@
 		);
 	}
 
-	// Directions are suppressed so that the info window holds only what the KML document
-	// contributed, rather than also the two Google Maps links geoxml3 adds for a point.
-	function parseKml( kml ) {
-		var parsedDocuments = [];
-
-		new geoXML3.parser( {
+	// The parser as jquery.googlemap.js builds it. Directions are suppressed so that the info
+	// window holds only what the KML document contributed, rather than also the two Google Maps
+	// links geoxml3 adds for a point.
+	function newParser( options ) {
+		return new geoXML3.parser( $.extend( {
 			map: mapStub,
 			zoom: false,
 			suppressDirections: true
-		} ).parseKmlString( kml, parsedDocuments );
+		}, options ) );
+	}
+
+	function parseKml( kml ) {
+		var parsedDocuments = [];
+
+		newParser( {} ).parseKmlString( kml, parsedDocuments );
 
 		return parsedDocuments[ 0 ];
 	}
@@ -298,6 +309,106 @@
 		);
 	} );
 
+	// How many fetches the stub below answers. Well above the nesting limit, and well below what it
+	// takes to run the browser out of stack, so a missing limit shows up as a failed assertion
+	// rather than as a crashed test run.
+	var ANSWERED_FETCHES = 20;
+
+	// The urls geoxml3 has the browser fetch for the documents the given KML document names.
+	// Fetching is stubbed out, so nothing leaves the browser, and every fetch is answered with
+	// responseKml, which is what lets a chain of documents be followed.
+	function fetchedUrls( options, kml, responseKml ) {
+		var requested = [];
+		var originalFetchXml = geoXML3.fetchXML;
+
+		geoXML3.fetchXML = function ( url, callback ) {
+			requested.push( url );
+			callback(
+				responseKml && requested.length < ANSWERED_FETCHES ?
+					geoXML3.xmlParse( responseKml ) :
+					undefined
+			);
+		};
+
+		try {
+			newParser( options ).parseKmlString( kml, [] );
+		} finally {
+			geoXML3.fetchXML = originalFetchXml;
+		}
+
+		return requested;
+	}
+
+	QUnit.test( 'NetworkLink to another host is fetched when external KML is allowed', function ( assert ) {
+		assert.deepEqual(
+			fetchedUrls(
+				{ allowExternalDocuments: true },
+				kmlWithLoadedNetworkLink( 'https://example.com/points.kml' ),
+				null
+			),
+			[ 'https://example.com/points.kml' ],
+			'The document the NetworkLink points at is fetched'
+		);
+	} );
+
+	QUnit.test( 'NetworkLink to another host is not fetched when external KML is not allowed', function ( assert ) {
+		assert.deepEqual(
+			fetchedUrls(
+				{ allowExternalDocuments: false },
+				kmlWithLoadedNetworkLink( 'https://example.com/points.kml' ),
+				null
+			),
+			[],
+			'Nothing is fetched from the other host'
+		);
+	} );
+
+	QUnit.test( 'NetworkLink to this wiki is fetched when external KML is not allowed', function ( assert ) {
+		assert.deepEqual(
+			fetchedUrls(
+				{ allowExternalDocuments: false },
+				kmlWithLoadedNetworkLink( window.location.origin + '/points.kml' ),
+				null
+			),
+			[ window.location.origin + '/points.kml' ],
+			'The document on the wiki itself is still fetched'
+		);
+	} );
+
+	QUnit.test( 'styleUrl on another host is fetched when external KML is allowed', function ( assert ) {
+		assert.deepEqual(
+			fetchedUrls(
+				{ allowExternalDocuments: true },
+				kmlWithPlacemark( '<styleUrl>https://example.com/styles.kml#pin</styleUrl>' ),
+				null
+			),
+			[ 'https://example.com/styles.kml' ],
+			'The document the style is defined in is fetched'
+		);
+	} );
+
+	QUnit.test( 'styleUrl on another host is not fetched when external KML is not allowed', function ( assert ) {
+		assert.deepEqual(
+			fetchedUrls(
+				{ allowExternalDocuments: false },
+				kmlWithPlacemark( '<styleUrl>https://example.com/styles.kml#pin</styleUrl>' ),
+				null
+			),
+			[],
+			'Nothing is fetched from the other host'
+		);
+	} );
+
+	QUnit.test( 'NetworkLink pointing at its own document stops at the nesting limit', function ( assert ) {
+		var selfReferencing = kmlWithLoadedNetworkLink( window.location.origin + '/points.kml' );
+
+		assert.strictEqual(
+			fetchedUrls( { allowExternalDocuments: true }, selfReferencing, selfReferencing ).length,
+			3,
+			'The cycle is followed a bounded number of times instead of forever'
+		);
+	} );
+
 	QUnit.test( 'Placemark description keeps a link target', function ( assert ) {
 		var content = renderInfoWindow( kmlWithPlacemark(
 			'<description><![CDATA[<a href="https://example.com/" target="_blank">Example</a>]]></description>'
@@ -328,4 +439,4 @@
 		);
 	} );
 
-}( window.mediaWiki ) );
+}( window.jQuery, window.mediaWiki ) );


### PR DESCRIPTION
The default is `true`, keeping today's behaviour, since flipping it would break existing wikis on a
minor release. Whether to make `false` the default is your call, not something this PR decides.

`gkml` is deliberately left alone: `google.maps.KmlLayer` documents are fetched and rendered by
Google's servers rather than by the reader's browser, so neither the IP leak nor the `NetworkLink`
recursion applies to it.

The nesting limit on `NetworkLink` applies regardless of the setting, since an unbounded fetch loop
is a problem on its own.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; detailed spec from @JeroenDeDauw, no revisions; diff not yet human-reviewed; PHPUnit, phpcs and PHPStan run locally, QUnit run in a browser against production ResourceLoader, and each new test confirmed failing without its production change.</sub>
