### PR TITLE
Move GeoJson page data from an inline script to a data attribute

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -325,12 +325,14 @@
 			"leaflet/FeatureBuilderTest.js",
 			"leaflet/JQueryLeafletTest.js",
 			"GoogleMaps/geoxml3/KmlRenderingTest.js",
-			"MapSaverTest.js"
+			"MapSaverTest.js",
+			"GeoJsonPageTest.js"
 		],
 		"dependencies": [
 			"ext.maps.leaflet.geojson",
 			"ext.maps.leaflet.loader",
-			"ext.maps.leaflet.editor"
+			"ext.maps.leaflet.editor",
+			"ext.maps.geojson.page"
 		]
 	},
 

--- a/resources/geoJsonPage.js
+++ b/resources/geoJsonPage.js
@@ -83,7 +83,7 @@
 		return $mapElement.data('mw-maps-geojson') || window.GeoJson;
 	}
 
-	mw.hook( 'wikipage.content' ).add( function ( $content ) {
+	function initializePage($content) {
 		let $mapElement = $content.find('#GeoJsonMap');
 
 		if ($mapElement.length === 0) {
@@ -103,10 +103,13 @@
 		addZoomControl(map);
 		addTitleLayer(map);
 		initializeGeoJsonAndEditorUi(map, getGeoJson($mapElement));
-	} );
+	}
+
+	mw.hook( 'wikipage.content' ).add( initializePage );
 
 	maps.geoJsonPage = {
-		getGeoJson: getGeoJson
+		getGeoJson: getGeoJson,
+		initializePage: initializePage
 	};
 
 })( window.jQuery, window.mediaWiki, window.maps );

--- a/resources/geoJsonPage.js
+++ b/resources/geoJsonPage.js
@@ -36,7 +36,7 @@
 		}
 	}
 
-	function initializeWithEditor(map) {
+	function initializeWithEditor(map, geoJson) {
 		let editor = maps.leaflet.LeafletEditor(
 			map,
 			new maps.MapSaver(mw.config.get('wgPageName'))
@@ -46,40 +46,52 @@
 			alert(mw.msg('maps-json-editor-changes-saved'));
 		});
 
-		editor.initialize(window.GeoJson);
+		editor.initialize(geoJson);
 
 		fitContent(map, editor.getLayer());
 	}
 
-	function initializePlainMap(map) {
+	function initializePlainMap(map, geoJson) {
 		fitContent(
 			map,
-			maps.leaflet.GeoJson.newGeoJsonLayer(L, window.GeoJson).addTo(map)
+			maps.leaflet.GeoJson.newGeoJsonLayer(L, geoJson).addTo(map)
 		);
 	}
 
-	function initializeGeoJsonAndEditorUi(map) {
+	function initializeGeoJsonAndEditorUi(map, geoJson) {
 		if (mw.config.get('wgCurRevisionId') === mw.config.get('wgRevisionId')) {
 
 			maps.api.canEditPage(mw.config.get('wgPageName')).done(
 				function(canEdit) {
 					if (canEdit) {
-						initializeWithEditor(map);
+						initializeWithEditor(map, geoJson);
 					}
 					else {
-						initializePlainMap(map);
+						initializePlainMap(map, geoJson);
 					}
 				}
 			);
 		}
 		else {
-			initializePlainMap(map);
+			initializePlainMap(map, geoJson);
 		}
 	}
 
+	// Pages rendered before the GeoJSON moved into the data attribute are still served from
+	// the parser cache, with the JSON in an inline script that assigns window.GeoJson.
+	function getGeoJson($mapElement) {
+		return $mapElement.data('mw-maps-geojson') || window.GeoJson;
+	}
+
 	mw.hook( 'wikipage.content' ).add( function ( $content ) {
+		let $mapElement = $content.find('#GeoJsonMap');
+
+		if ($mapElement.length === 0) {
+			return;
+		}
+
 		let map = L.map(
-			'GeoJsonMap',
+			$mapElement.get(0),
 			{
 				fullscreenControl: true,
 				fullscreenControlOptions: {position: 'topright'},
@@ -90,7 +102,11 @@
 		hideLoadingMessage(map, $content);
 		addZoomControl(map);
 		addTitleLayer(map);
-		initializeGeoJsonAndEditorUi(map);
+		initializeGeoJsonAndEditorUi(map, getGeoJson($mapElement));
 	} );
+
+	maps.geoJsonPage = {
+		getGeoJson: getGeoJson
+	};
 
 })( window.jQuery, window.mediaWiki, window.maps );

--- a/src/GeoJsonPages/GeoJsonMapPageUi.php
+++ b/src/GeoJsonPages/GeoJsonMapPageUi.php
@@ -20,22 +20,8 @@ class GeoJsonMapPageUi {
 	}
 
 	public function addToOutput( OutputFacade $output ) {
-		$output->addHtml( $this->getJavascript() . $this->getHtml() );
+		$output->addHtml( $this->getHtml() );
 		$output->addModules( 'ext.maps.geojson.page' );
-	}
-
-	private function getJavascript(): string {
-		return Html::element(
-			'script',
-			[],
-			$this->getJsonJs()
-		);
-	}
-
-	private function getJsonJs(): string {
-		return 'var GeoJson ='
-			. $this->json
-			. ';';
 	}
 
 	private function getHtml(): string {
@@ -45,7 +31,8 @@ class GeoJsonMapPageUi {
 				[
 					'id' => 'GeoJsonMap',
 					'style' => 'width: 100%; height: 600px; background-color: #eeeeee; overflow: hidden;',
-					'class' => 'maps-map maps-leaflet maps-geojson-editor'
+					'class' => 'maps-map maps-leaflet maps-geojson-editor',
+					'data-mw-maps-geojson' => $this->json
 				],
 				Html::element(
 					'div',

--- a/tests/Integration/GeoJsonPages/GeoJsonMapPageUiTest.php
+++ b/tests/Integration/GeoJsonPages/GeoJsonMapPageUiTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Maps\Tests\Integration\GeoJsonPages;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+use Maps\GeoJsonPages\GeoJsonContent;
+use Maps\GeoJsonPages\GeoJsonMapPageUi;
+use Maps\Presentation\OutputFacade;
+use MediaWiki\Parser\ParserOutput;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Maps\GeoJsonPages\GeoJsonMapPageUi
+ */
+class GeoJsonMapPageUiTest extends TestCase {
+
+	public function testValuesReachTheClientUnchanged() {
+		// The combining long solidus overlay turns the preceding "=" into "≠".
+		$title = "Tea & Coffee <b>Ltd</b>, open =\u{0338} closed";
+
+		$this->assertSame( $title, $this->titleHandedToClient( $title ) );
+	}
+
+	private function titleHandedToClient( string $title ): string {
+		$geoJson = json_decode( $this->geoJsonHandedToClient( $title ) );
+
+		return $geoJson->features[0]->properties->title;
+	}
+
+	/**
+	 * Returns the GeoJSON the way the browser hands it to the map JavaScript. The HTML parser
+	 * decodes character references in attribute values, so this is the page JSON, unmodified.
+	 */
+	private function geoJsonHandedToClient( string $title ): string {
+		return $this->mapElement( $this->renderPage( $title ) )->getAttribute( 'data-mw-maps-geojson' );
+	}
+
+	private function renderPage( string $title ): string {
+		$parserOutput = new ParserOutput();
+
+		GeoJsonMapPageUi::forExistingPage( $this->pageJson( $title ) )
+			->addToOutput( OutputFacade::newFromParserOutput( $parserOutput ) );
+
+		return $parserOutput->getRawText();
+	}
+
+	private function pageJson( string $title ): string {
+		return GeoJsonContent::formatJson( (object)[
+			'type' => 'FeatureCollection',
+			'features' => [
+				(object)[
+					'type' => 'Feature',
+					'properties' => (object)[ 'title' => $title ],
+					'geometry' => (object)[ 'type' => 'Point', 'coordinates' => [ 4.35, 50.85 ] ]
+				]
+			]
+		] );
+	}
+
+	private function mapElement( string $html ): DOMElement {
+		$document = new DOMDocument();
+		$document->loadHTML( '<meta charset="utf-8">' . $html, LIBXML_NOERROR );
+
+		$element = ( new DOMXPath( $document ) )->query( '//*[@id="GeoJsonMap"]' )->item( 0 );
+
+		$this->assertInstanceOf( DOMElement::class, $element, 'The page should contain the map element' );
+
+		return $element;
+	}
+
+}

--- a/tests/js/GeoJsonPageTest.js
+++ b/tests/js/GeoJsonPageTest.js
@@ -1,0 +1,48 @@
+( function ( $ ) {
+	'use strict';
+
+	function mapElementWith( geoJson ) {
+		return $( '<div>' ).attr( 'data-mw-maps-geojson', JSON.stringify( geoJson ) );
+	}
+
+	function pointNamed( name ) {
+		return {
+			type: 'FeatureCollection',
+			features: [ {
+				type: 'Feature',
+				properties: { title: name },
+				geometry: { type: 'Point', coordinates: [ 4.35, 50.85 ] }
+			} ]
+		};
+	}
+
+	QUnit.module( 'Maps.geoJsonPage' );
+
+	QUnit.test( 'GeoJSON is read from the map element', function ( assert ) {
+		var geoJson = pointNamed( 'Brussels' );
+
+		assert.deepEqual( maps.geoJsonPage.getGeoJson( mapElementWith( geoJson ) ), geoJson );
+	} );
+
+	QUnit.test( 'ampersands and angle brackets in values are read unchanged', function ( assert ) {
+		var geoJson = pointNamed( 'Tea & Coffee <b>Ltd</b>' );
+
+		assert.deepEqual( maps.geoJsonPage.getGeoJson( mapElementWith( geoJson ) ), geoJson );
+	} );
+
+	QUnit.module( 'Maps.geoJsonPage with cached inline script markup', {
+		beforeEach: function () {
+			this.originalGeoJson = window.GeoJson;
+		},
+		afterEach: function () {
+			window.GeoJson = this.originalGeoJson;
+		}
+	} );
+
+	QUnit.test( 'GeoJSON falls back to the global when the map element has no data attribute', function ( assert ) {
+		window.GeoJson = pointNamed( 'Brussels' );
+
+		assert.deepEqual( maps.geoJsonPage.getGeoJson( $( '<div>' ) ), window.GeoJson );
+	} );
+
+}( window.jQuery ) );

--- a/tests/js/GeoJsonPageTest.js
+++ b/tests/js/GeoJsonPageTest.js
@@ -24,10 +24,23 @@
 		assert.deepEqual( maps.geoJsonPage.getGeoJson( mapElementWith( geoJson ) ), geoJson );
 	} );
 
-	QUnit.test( 'ampersands and angle brackets in values are read unchanged', function ( assert ) {
-		var geoJson = pointNamed( 'Tea & Coffee <b>Ltd</b>' );
+	// The attribute as GeoJsonMapPageUi emits it: quotes and newlines entity-encoded,
+	// U+0338 as &#x338;, and & < > as JSON \uXXXX escapes.
+	QUnit.test( 'values in page markup survive entity decoding unchanged', function ( assert ) {
+		var $mapElement = $(
+			'<div data-mw-maps-geojson="{&#10;' +
+			'    &quot;type&quot;: &quot;FeatureCollection&quot;,&#10;' +
+			'    &quot;features&quot;: [ {&#10;' +
+			'        &quot;type&quot;: &quot;Feature&quot;,&#10;' +
+			'        &quot;properties&quot;: { &quot;title&quot;: &quot;Tea \\u0026 Coffee \\u003Cb\\u003ELtd, open =&#x338; closed&quot; },&#10;' +
+			'        &quot;geometry&quot;: { &quot;type&quot;: &quot;Point&quot;, &quot;coordinates&quot;: [ 4.35, 50.85 ] }&#10;' +
+			'    } ]&#10;}"></div>'
+		);
 
-		assert.deepEqual( maps.geoJsonPage.getGeoJson( mapElementWith( geoJson ) ), geoJson );
+		assert.strictEqual(
+			maps.geoJsonPage.getGeoJson( $mapElement ).features[ 0 ].properties.title,
+			'Tea & Coffee <b>Ltd, open =\u0338 closed'
+		);
 	} );
 
 	QUnit.module( 'Maps.geoJsonPage page initialization' );
@@ -53,6 +66,15 @@
 		window.GeoJson = pointNamed( 'Brussels' );
 
 		assert.deepEqual( maps.geoJsonPage.getGeoJson( $( '<div>' ) ), window.GeoJson );
+	} );
+
+	QUnit.test( 'the map element wins over the global when both are present', function ( assert ) {
+		window.GeoJson = pointNamed( 'Cached global' );
+
+		assert.deepEqual(
+			maps.geoJsonPage.getGeoJson( mapElementWith( pointNamed( 'Brussels' ) ) ),
+			pointNamed( 'Brussels' )
+		);
 	} );
 
 }( window.jQuery ) );

--- a/tests/js/GeoJsonPageTest.js
+++ b/tests/js/GeoJsonPageTest.js
@@ -30,6 +30,16 @@
 		assert.deepEqual( maps.geoJsonPage.getGeoJson( mapElementWith( geoJson ) ), geoJson );
 	} );
 
+	QUnit.module( 'Maps.geoJsonPage page initialization' );
+
+	QUnit.test( 'content without a GeoJson map is left untouched', function ( assert ) {
+		var $content = $( '<div><p>No map here</p></div>' );
+
+		maps.geoJsonPage.initializePage( $content );
+
+		assert.strictEqual( $content.find( '.leaflet-container' ).length, 0 );
+	} );
+
 	QUnit.module( 'Maps.geoJsonPage with cached inline script markup', {
 		beforeEach: function () {
 			this.originalGeoJson = window.GeoJson;


### PR DESCRIPTION
Not a bug fix. The inline script does not corrupt values: `GeoJsonContent::formatJson()` goes through `FormatJson::encode()` without `XMLMETA_OK`, so `<`, `>` and `&` are already hex-escaped before `Html::element()` sees them. What this buys is one less inline script, one less global, and the same `data-mw-maps-*` attribute the other maps use.

The `window.GeoJson` fallback is only for pages still served from the parser cache with the old markup, and can go once those turn over.

> <sub>AI-authored — Claude Code, `Opus (max)`; follow-up ask from @JeroenDeDauw, whose premise (that the inline script corrupted values) the investigation disproved, so this was rescoped from bug fix to cleanup; diff not yet human-reviewed; PHPUnit, phpcs, PHPStan and QUnit run locally, the fallback mutation-checked, and all three render paths loaded in a browser on a real GeoJson page.</sub>

<details><summary>Production notes</summary>

Spec and review by `Fable 5 (max)`, implementation by an `Opus (max)` subagent. It stopped short of opening this PR because the reported bug did not exist; the branch is offered as optional cleanup rather than as the fix that was asked for. The one real instance of the escaping mechanism is U+0338 COMBINING LONG SOLIDUS OVERLAY, which `Sanitizer::escapeCombiningChar()` rewrites to `&#x338;` and a raw-text `<script>` then passes through verbatim.

</details>
