### PR TITLE
Update INSTALL.md with new version release details

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,18 +25,32 @@ minimum requirements are indicated in bold. For a detailed list of changes, see 
 		<th>Release status<br>&nbsp;</th>
 	</tr>
 	<tr>
+		<th>14.1.x</th>
+		<td>8.1+</td>
+		<td>1.43+</td>
+		<td>7.0+</td>
+		<td>Future release</td>
+	</tr>
+	<tr>
+		<th>14.0.x</th>
+		<td>8.1+</td>
+		<td>1.43+</td>
+		<td><strong>7.0</strong> - 7.2</td>
+		<td>Stable release</td>
+	</tr>	
+	<tr>
 		<th>13.0.x</th>
 		<td><strong>8.1</strong>+</td>
-		<td><strong>1.43</strong>+</td>
+		<td><strong>1.43</strong> - 1.46</td>
 		<td><strong>5.0</strong> - 6.x</td>
-		<td>Future version</td>
+		<td>Obsolete</td>
 	</tr>
 	<tr>
 		<th>12.1.x</th>
 		<td>7.4 - 8.4</td>
 		<td>1.43 - 1.44</td>
 		<td>4.2 - 6.0</td>
-		<td>Stable release</td>
+		<td>Obsolete</td>
 	</tr>
 	<tr>
 		<th>12.0.x</th>


### PR DESCRIPTION
Added version information for 14.1.x and 14.0.x releases, marking 14.0.x as stable and updating the status of 13.0.x and 12.1.x to obsolete.